### PR TITLE
fix stub for mobius-pipeline

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+ignore_missing_imports = False
+allow_redefinition = True
+mypy_path = $MYPY_CONFIG_FILE_DIR/aana:./mobius-pipeline


### PR DESCRIPTION
Summery:

Adding mypy config, so the mobius-pipeline types can be used directly from the source without adding stub for it.