### PR TITLE
adding bfloat type to core.model.types

### DIFF
--- a/aana/core/models/types.py
+++ b/aana/core/models/types.py
@@ -14,12 +14,14 @@ class Dtype(str, Enum):
         AUTO (str): auto
         FLOAT32 (str): float32
         FLOAT16 (str): float16
+        BFLOAT16 (str): bfloat16
         INT8 (str): int8
     """
 
     AUTO = "auto"
     FLOAT32 = "float32"
     FLOAT16 = "float16"
+    BFLOAT16 = "bfloat16"
     INT8 = "int8"
 
     def to_torch(self) -> torch.dtype | str:
@@ -38,6 +40,8 @@ class Dtype(str, Enum):
                 return torch.float32
             case self.FLOAT16:
                 return torch.float16
+            case self.BFLOAT16:
+                return torch.bfloat16
             case self.INT8:
                 return torch.int8
             case _:


### PR DESCRIPTION
Noticed we don't have bfloat16 in the types. Including them in core.models.types 