### PR TITLE
Updated Pydantic Model Configurations for Protected Fields

### DIFF
--- a/aana/configs/settings.py
+++ b/aana/configs/settings.py
@@ -1,9 +1,10 @@
 from pathlib import Path
 
-from pydantic import field_validator
+from pydantic import ConfigDict, field_validator
 from pydantic_settings import BaseSettings
 
 from aana.configs.db import DbSettings
+from aana.core.models.base import pydantic_protected_fields
 
 
 class TestSettings(BaseSettings):
@@ -67,6 +68,10 @@ class Settings(BaseSettings):
         """Create the tmp_data_dir if it doesn't exist."""
         path.mkdir(parents=True, exist_ok=True)
         return path
+
+    model_config = ConfigDict(
+        protected_namespaces=("settings", *pydantic_protected_fields)
+    )
 
 
 settings = Settings()

--- a/aana/core/models/base.py
+++ b/aana/core/models/base.py
@@ -81,3 +81,26 @@ def pydantic_to_dict(data: Any) -> Any:
         return {key: pydantic_to_dict(value) for key, value in data.items()}
     else:
         return data  # return as is for non-Pydantic types
+
+
+# Workaround for the annoying issue with Pydantic's protected fields.
+# See: https://github.com/pydantic/pydantic/issues/9177
+# TODO: Remove this workaround once the issue is resolved.
+pydantic_protected_fields = [
+    "model_computed_fields",
+    "model_config",
+    "model_construct",
+    "model_copy",
+    "model_dump",
+    "model_dump_json",
+    "model_extra",
+    "model_fields",
+    "model_fields_set",
+    "model_json_schema",
+    "model_parametrized_name",
+    "model_post_init",
+    "model_rebuild",
+    "model_validate",
+    "model_validate_json",
+    "model_validate_strings",
+]

--- a/aana/core/models/chat.py
+++ b/aana/core/models/chat.py
@@ -2,6 +2,8 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from aana.core.models.base import pydantic_protected_fields
+
 __all__ = [
     "Role",
     "Prompt",
@@ -169,6 +171,8 @@ class ChatCompletionRequest(BaseModel):
         ),
     )
 
+    model_config = ConfigDict(protected_namespaces=(*pydantic_protected_fields,))
+
 
 class ChatCompletionChoice(BaseModel):
     """A chat completion choice for OpenAI compatible API.
@@ -211,3 +215,5 @@ class ChatCompletion(BaseModel):
         "chat.completion",
         description="The object type, which is always `chat.completion`.",
     )
+
+    model_config = ConfigDict(protected_namespaces=(*pydantic_protected_fields,))

--- a/aana/deployments/hf_blip2_deployment.py
+++ b/aana/deployments/hf_blip2_deployment.py
@@ -2,11 +2,12 @@ from typing import Any
 
 import torch
 import transformers
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from ray import serve
 from transformers import Blip2ForConditionalGeneration, Blip2Processor
 from typing_extensions import TypedDict
 
+from aana.core.models.base import pydantic_protected_fields
 from aana.core.models.captions import Caption, CaptionsList
 from aana.core.models.image import Image
 from aana.core.models.types import Dtype
@@ -31,6 +32,8 @@ class HFBlip2Config(BaseModel):
     batch_size: int = Field(default=1)
     num_processing_threads: int = Field(default=1)
     max_new_tokens: int = Field(default=64)
+
+    model_config = ConfigDict(protected_namespaces=(*pydantic_protected_fields,))
 
 
 class CaptioningOutput(TypedDict):

--- a/aana/deployments/hf_pipeline_deployment.py
+++ b/aana/deployments/hf_pipeline_deployment.py
@@ -2,10 +2,11 @@ from copy import copy, deepcopy
 from typing import Any
 
 import torch
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from ray import serve
 from transformers import pipeline
 
+from aana.core.models.base import pydantic_protected_fields
 from aana.core.models.custom_config import CustomConfig
 from aana.core.models.image import Image
 from aana.deployments.base_deployment import BaseDeployment
@@ -27,6 +28,8 @@ class HfPipelineConfig(BaseModel):
     model_kwargs: CustomConfig = {}
     pipeline_kwargs: CustomConfig = {}
     generation_kwargs: CustomConfig = {}
+
+    model_config = ConfigDict(protected_namespaces=(*pydantic_protected_fields,))
 
 
 @serve.deployment

--- a/aana/deployments/hf_text_generation_deployment.py
+++ b/aana/deployments/hf_text_generation_deployment.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import torch
 import transformers
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from ray import serve
 from transformers import (
     AutoModelForCausalLM,
@@ -14,7 +14,7 @@ from transformers import (
     TextIteratorStreamer,
 )
 
-from aana.core.models.base import merged_options
+from aana.core.models.base import merged_options, pydantic_protected_fields
 from aana.core.models.sampling import SamplingParams
 from aana.deployments.base_text_generation_deployment import (
     BaseTextGenerationDeployment,
@@ -40,6 +40,8 @@ class HfTextGenerationConfig(BaseModel):
         temperature=0, max_tokens=256
     )
     chat_template: str | None = None
+
+    model_config = ConfigDict(protected_namespaces=(*pydantic_protected_fields,))
 
 
 async def async_streamer_adapter(streamer):

--- a/aana/deployments/idefics_2_deployment.py
+++ b/aana/deployments/idefics_2_deployment.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import torch
 import transformers
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from ray import serve
 from transformers import (
     AutoModelForVision2Seq,
@@ -15,7 +15,7 @@ from transformers import (
 )
 from transformers.utils.import_utils import is_flash_attn_2_available
 
-from aana.core.models.base import merged_options
+from aana.core.models.base import merged_options, pydantic_protected_fields
 from aana.core.models.chat import ChatMessage
 from aana.core.models.custom_config import CustomConfig
 from aana.core.models.image_chat import ImageChatDialog
@@ -58,6 +58,7 @@ class Idefics2Config(BaseModel):
     default_sampling_params: SamplingParams = SamplingParams(
         temperature=1.0, max_tokens=256
     )
+    model_config = ConfigDict(protected_namespaces=(*pydantic_protected_fields,))
 
 
 @serve.deployment

--- a/aana/deployments/sentence_transformer_deployment.py
+++ b/aana/deployments/sentence_transformer_deployment.py
@@ -1,11 +1,12 @@
 from typing import Any
 
 import numpy as np
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from ray import serve
 from sentence_transformers import SentenceTransformer
 from typing_extensions import TypedDict
 
+from aana.core.models.base import pydantic_protected_fields
 from aana.deployments.base_deployment import BaseDeployment
 from aana.exceptions.runtime import InferenceException
 from aana.processors.batch import BatchProcessor
@@ -23,6 +24,8 @@ class SentenceTransformerConfig(BaseModel):
     model: str
     batch_size: int = Field(default=1)
     num_processing_threads: int = Field(default=1)
+
+    model_config = ConfigDict(protected_namespaces=(*pydantic_protected_fields,))
 
 
 class SentenceTransformerOutput(TypedDict):

--- a/aana/deployments/vad_deployment.py
+++ b/aana/deployments/vad_deployment.py
@@ -3,10 +3,11 @@ from typing import Any, TypedDict
 
 import torch
 from pyannote.audio import Model
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from ray import serve
 
 from aana.core.models.audio import Audio
+from aana.core.models.base import pydantic_protected_fields
 from aana.core.models.time import TimeInterval
 from aana.core.models.vad import VadParams, VadSegment
 from aana.deployments.base_deployment import BaseDeployment
@@ -78,6 +79,8 @@ class VadConfig(BaseModel):
     )
 
     sample_rate: int = Field(default=16000, description="Sample rate of the audio.")
+
+    model_config = ConfigDict(protected_namespaces=(*pydantic_protected_fields,))
 
 
 @serve.deployment

--- a/aana/deployments/vllm_deployment.py
+++ b/aana/deployments/vllm_deployment.py
@@ -2,7 +2,7 @@ import contextlib
 from collections.abc import AsyncGenerator
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from ray import serve
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine
@@ -23,6 +23,7 @@ with contextlib.suppress(ImportError):
 from vllm.sampling_params import SamplingParams as VLLMSamplingParams
 from vllm.utils import random_uuid
 
+from aana.core.models.base import pydantic_protected_fields
 from aana.core.models.sampling import SamplingParams
 from aana.exceptions.runtime import InferenceException, PromptTooLongException
 
@@ -56,6 +57,8 @@ class VLLMConfig(BaseModel):
     chat_template: str | None = Field(default=None)
     enforce_eager: bool | None = Field(default=False)
     engine_args: CustomConfig = {}
+
+    model_config = ConfigDict(protected_namespaces=(*pydantic_protected_fields,))
 
 
 @serve.deployment

--- a/aana/deployments/whisper_deployment.py
+++ b/aana/deployments/whisper_deployment.py
@@ -4,7 +4,7 @@ from typing import Any, cast
 
 import torch
 from faster_whisper import WhisperModel
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from ray import serve
 from typing_extensions import TypedDict
 
@@ -14,6 +14,7 @@ from aana.core.models.asr import (
     AsrTranscriptionInfo,
 )
 from aana.core.models.audio import Audio
+from aana.core.models.base import pydantic_protected_fields
 from aana.core.models.whisper import (
     WhisperParams,
 )
@@ -94,6 +95,8 @@ class WhisperConfig(BaseModel):
     compute_type: WhisperComputeType = Field(
         default=WhisperComputeType.FLOAT16, description="The compute type."
     )
+
+    model_config = ConfigDict(protected_namespaces=(*pydantic_protected_fields,))
 
 
 class WhisperOutput(TypedDict):


### PR DESCRIPTION
**Summary**

This pull request addresses the issue of warnings generated by Pydantic when using field names that conflict with Pydantic's protected namespaces. Specifically, warnings like the following were observed:

```
/root/.cache/pypoetry/virtualenvs/aana-vIr3-B0u-py3.10/lib/python3.10/site-packages/pydantic/_internal/_fields.py:161: 
UserWarning: Field "model_dir" has a conflict with protected namespace "model_".
```

**Key Changes**:
- Compiled a list of protected field names (`pydantic_protected_fields`).
- Integrated this list into the model configuration by redefining the `protected_namespaces` in the `ConfigDict` as follows:
  ```python
  model_config = ConfigDict(protected_namespaces=(*pydantic_protected_fields,))
  ```

#### Rationale
This is a workaround to prevent warnings caused by naming conflicts between user-defined fields and Pydantic's internal protected namespaces. While this is not an ideal solution, it effectively mitigates the warning until a more comprehensive fix is provided by the Pydantic team.

For further context, this issue is also being discussed in the Pydantic community, as evidenced by this [GitHub issue](https://github.com/pydantic/pydantic/issues/9177).

**Notes**
- This change is intended as a temporary measure. The ideal solution would involve changes in Pydantic itself to better handle such conflicts.
- Developers should be aware that this workaround may need to be revisited when a proper fix is implemented by Pydantic.
- When a new model with conflicting field is introduced, use the same model_config to mitigate the issue.

**References**: https://github.com/pydantic/pydantic/issues/9177