### PR TITLE
fix for locale

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,6 @@
 FROM nvidia/cuda:12.1.0-cudnn8-devel-ubuntu22.04
-RUN apt-get update && apt-get install -y libgl1 libglib2.0-0 ffmpeg
+RUN apt-get update && apt-get install -y libgl1 libglib2.0-0 ffmpeg locales
+
+# Set the locale
+RUN locale-gen en_US.UTF-8
+ENV LANG="en_US.UTF-8" LANGUAGE="en_US:en" LC_ALL="en_US.UTF-8"


### PR DESCRIPTION
Fix for:
The tests for postgres db are failing when running directly via command line in the devcontainer
Key changes:
- Adding locale in and set it inside devcontainer dockerfile