### PR TITLE
Support for Multiple Instances of TaskQueueDeployment

### DIFF
--- a/aana/storage/op.py
+++ b/aana/storage/op.py
@@ -12,7 +12,12 @@ from aana.utils.json import jsonify
 
 
 class DbType(str, Enum):
-    """Engine types for relational database."""
+    """Engine types for relational database.
+
+    Attributes:
+        POSTGRESQL: PostgreSQL database.
+        SQLITE: SQLite database.
+    """
 
     POSTGRESQL = "postgresql"
     SQLITE = "sqlite"

--- a/aana/storage/repository/task.py
+++ b/aana/storage/repository/task.py
@@ -92,7 +92,8 @@ class TaskRepository(BaseRepository[TaskEntity]):
             )
             .order_by(desc(TaskEntity.priority), TaskEntity.created_at)
             .limit(limit)
-            .with_for_update()
+            .populate_existing()
+            .with_for_update(skip_locked=True)
             .all()
         )
         for task in tasks:
@@ -214,7 +215,8 @@ class TaskRepository(BaseRepository[TaskEntity]):
                     TaskEntity.updated_at <= cutoff_time,
                 ),
             )
-            .with_for_update()
+            .populate_existing()
+            .with_for_update(skip_locked=True)
             .all()
         )
         for task in tasks:

--- a/aana/storage/repository/task.py
+++ b/aana/storage/repository/task.py
@@ -67,10 +67,17 @@ class TaskRepository(BaseRepository[TaskEntity]):
         self.session.commit()
         return task
 
-    def get_unprocessed_tasks(self, limit: int | None = None) -> list[TaskEntity]:
-        """Fetches all unprocessed tasks.
+    def fetch_unprocessed_tasks(self, limit: int | None = None) -> list[TaskEntity]:
+        """Fetches unprocessed tasks and marks them as ASSIGNED.
 
         The task is considered unprocessed if it is in CREATED or NOT_FINISHED state.
+
+        The function runs in a transaction and locks the rows to prevent race condition
+        if multiple task queue deployments are running concurrently.
+
+        IMPORTANT: The lock doesn't work with SQLite. If you are using SQLite, you should
+        only run one task queue deployment at a time. Otherwise, you may encounter
+        race conditions.
 
         Args:
             limit (int | None): The maximum number of tasks to fetch. If None, fetch all.
@@ -85,8 +92,17 @@ class TaskRepository(BaseRepository[TaskEntity]):
             )
             .order_by(desc(TaskEntity.priority), TaskEntity.created_at)
             .limit(limit)
+            .with_for_update()
             .all()
         )
+        for task in tasks:
+            self.update_status(
+                task_id=task.id,
+                status=TaskStatus.ASSIGNED,
+                progress=0,
+                commit=False,
+            )
+        self.session.commit()
         return tasks
 
     def update_status(
@@ -95,6 +111,7 @@ class TaskRepository(BaseRepository[TaskEntity]):
         status: TaskStatus,
         progress: int | None = None,
         result: Any = None,
+        commit: bool = True,
     ):
         """Update the status of a task.
 
@@ -103,6 +120,7 @@ class TaskRepository(BaseRepository[TaskEntity]):
             status (TaskStatus): The new status.
             progress (int | None): The progress. If None, the progress will not be updated.
             result (Any): The result.
+            commit (bool): Whether to commit the transaction.
         """
         task = self.read(task_id)
         if status == TaskStatus.COMPLETED or status == TaskStatus.FAILED:
@@ -114,7 +132,8 @@ class TaskRepository(BaseRepository[TaskEntity]):
             task.progress = progress
         task.status = status
         task.result = result
-        self.session.commit()
+        if commit:
+            self.session.commit()
 
     def get_active_tasks(self) -> list[TaskEntity]:
         """Fetches all active tasks.
@@ -160,14 +179,28 @@ class TaskRepository(BaseRepository[TaskEntity]):
         incomplete_task_ids = [str(task.id) for task in tasks]
         return incomplete_task_ids
 
-    def get_expired_tasks(self, execution_timeout: float) -> list[TaskEntity]:
-        """Fetches all tasks that are expired.
+    def update_expired_tasks(
+        self, execution_timeout: float, max_retries: int
+    ) -> list[TaskEntity]:
+        """Fetches all tasks that are expired and updates their status.
 
         The task is considered expired if it is in RUNNING or ASSIGNED state and the
         updated_at time is older than the execution_timeout.
 
+        If the task has exceeded the maximum number of retries, it will be marked as FAILED.
+        If the task has not exceeded the maximum number of retries, it will be marked as NOT_FINISHED and
+        be retried again.
+
+        The function runs in a transaction and locks the rows to prevent race condition
+        if multiple task queue deployments are running concurrently.
+
+        IMPORTANT: The lock doesn't work with SQLite. If you are using SQLite, you should
+        only run one task queue deployment at a time. Otherwise, you may encounter
+        race conditions.
+
         Args:
             execution_timeout (float): The maximum execution time for a task in seconds
+            max_retries (int): The maximum number of retries for a task
 
         Returns:
             list[TaskEntity]: the expired tasks.
@@ -181,6 +214,30 @@ class TaskRepository(BaseRepository[TaskEntity]):
                     TaskEntity.updated_at <= cutoff_time,
                 ),
             )
+            .with_for_update()
             .all()
         )
+        for task in tasks:
+            if task.num_retries >= max_retries:
+                self.update_status(
+                    task_id=task.id,
+                    status=TaskStatus.FAILED,
+                    progress=0,
+                    result={
+                        "error": "TimeoutError",
+                        "message": (
+                            f"Task execution timed out after {execution_timeout} seconds and "
+                            f"exceeded the maximum number of retries ({max_retries})"
+                        ),
+                    },
+                    commit=False,
+                )
+            else:
+                self.update_status(
+                    task_id=task.id,
+                    status=TaskStatus.NOT_FINISHED,
+                    progress=0,
+                    commit=False,
+                )
+        self.session.commit()
         return tasks

--- a/aana/tests/db/datastore/test_task_repo.py
+++ b/aana/tests/db/datastore/test_task_repo.py
@@ -45,44 +45,49 @@ def test_get_unprocessed_tasks(db_session):
     """Test fetching unprocessed tasks."""
     task_repo = TaskRepository(db_session)
 
-    # Remove all existing tasks
-    db_session.query(TaskEntity).delete()
-    db_session.commit()
+    def _create_sample_tasks():
+        # Remove all existing tasks
+        db_session.query(TaskEntity).delete()
+        db_session.commit()
 
-    # Create sample tasks with different statuses
-    now = datetime.now()  # noqa: DTZ005
+        # Create sample tasks with different statuses
+        now = datetime.now()  # noqa: DTZ005
 
-    task1 = TaskEntity(
-        endpoint="/test1",
-        data={"test": "data1"},
-        status=TaskStatus.CREATED,
-        priority=1,
-        created_at=now - timedelta(hours=10),
-    )
-    task2 = TaskEntity(
-        endpoint="/test2",
-        data={"test": "data2"},
-        status=TaskStatus.NOT_FINISHED,
-        priority=2,
-        created_at=now - timedelta(hours=1),
-    )
-    task3 = TaskEntity(
-        endpoint="/test3",
-        data={"test": "data3"},
-        status=TaskStatus.COMPLETED,
-        priority=3,
-        created_at=now - timedelta(hours=2),
-    )
-    task4 = TaskEntity(
-        endpoint="/test4",
-        data={"test": "data4"},
-        status=TaskStatus.CREATED,
-        priority=2,
-        created_at=now - timedelta(hours=3),
-    )
+        task1 = TaskEntity(
+            endpoint="/test1",
+            data={"test": "data1"},
+            status=TaskStatus.CREATED,
+            priority=1,
+            created_at=now - timedelta(hours=10),
+        )
+        task2 = TaskEntity(
+            endpoint="/test2",
+            data={"test": "data2"},
+            status=TaskStatus.NOT_FINISHED,
+            priority=2,
+            created_at=now - timedelta(hours=1),
+        )
+        task3 = TaskEntity(
+            endpoint="/test3",
+            data={"test": "data3"},
+            status=TaskStatus.COMPLETED,
+            priority=3,
+            created_at=now - timedelta(hours=2),
+        )
+        task4 = TaskEntity(
+            endpoint="/test4",
+            data={"test": "data4"},
+            status=TaskStatus.CREATED,
+            priority=2,
+            created_at=now - timedelta(hours=3),
+        )
 
-    db_session.add_all([task1, task2, task3, task4])
-    db_session.commit()
+        db_session.add_all([task1, task2, task3, task4])
+        db_session.commit()
+        return task1, task2, task3, task4
+
+    # Create sample tasks
+    task1, task2, task3, task4 = _create_sample_tasks()
 
     # Fetch unprocessed tasks without any limit
     unprocessed_tasks = task_repo.fetch_unprocessed_tasks()
@@ -97,6 +102,9 @@ def test_get_unprocessed_tasks(db_session):
     assert unprocessed_tasks[0].id == task4.id  # Highest priority
     assert unprocessed_tasks[1].id == task2.id  # Same priority, but a newer task
     assert unprocessed_tasks[2].id == task1.id  # Lowest priority
+
+    # Create sample tasks
+    task1, task2, task3, task4 = _create_sample_tasks()
 
     # Fetch unprocessed tasks with a limit
     limited_tasks = task_repo.fetch_unprocessed_tasks(limit=2)

--- a/aana/tests/db/datastore/test_task_repo.py
+++ b/aana/tests/db/datastore/test_task_repo.py
@@ -85,7 +85,7 @@ def test_get_unprocessed_tasks(db_session):
     db_session.commit()
 
     # Fetch unprocessed tasks without any limit
-    unprocessed_tasks = task_repo.get_unprocessed_tasks()
+    unprocessed_tasks = task_repo.fetch_unprocessed_tasks()
 
     # Assert that only tasks with CREATED and NOT_FINISHED status are returned
     assert len(unprocessed_tasks) == 3
@@ -99,7 +99,7 @@ def test_get_unprocessed_tasks(db_session):
     assert unprocessed_tasks[2].id == task1.id  # Lowest priority
 
     # Fetch unprocessed tasks with a limit
-    limited_tasks = task_repo.get_unprocessed_tasks(limit=2)
+    limited_tasks = task_repo.fetch_unprocessed_tasks(limit=2)
 
     # Assert that only the specified number of tasks is returned
     assert len(limited_tasks) == 2
@@ -245,8 +245,8 @@ def test_remove_completed_tasks(db_session):
     assert set(non_completed_task_ids) == {str(task.id) for task in unfinished_tasks}
 
 
-def test_get_expired_tasks(db_session):
-    """Test fetching expired tasks."""
+def test_update_expired_tasks(db_session):
+    """Test updating expired tasks."""
     task_repo = TaskRepository(db_session)
 
     # Remove all existing tasks
@@ -293,7 +293,9 @@ def test_get_expired_tasks(db_session):
     db_session.commit()
 
     # Fetch expired tasks
-    expired_tasks = task_repo.get_expired_tasks(execution_timeout)
+    expired_tasks = task_repo.update_expired_tasks(
+        execution_timeout=execution_timeout, max_retries=3
+    )
 
     # Assert that only tasks with RUNNING or ASSIGNED status and an updated_at older than the cutoff are returned
     expected_task_ids = {str(task1.id)}


### PR DESCRIPTION
This Pull Request enhances the TaskQueueDeployment to support multiple concurrent instances. It introduces mechanisms to avoid race conditions during task allocation and processing.

Closes: https://github.com/mobiusml/aana_sdk/issues/186