### PR TITLE
Fixes for GPU Tests with dstack

### DIFF
--- a/.github/workflows/run_tests_with_gpu.yml
+++ b/.github/workflows/run_tests_with_gpu.yml
@@ -34,4 +34,4 @@ jobs:
     
     - name: Run tests with GPU
       run: |
-        HF_TOKEN=${{ secrets.HF_TOKEN }} dstack apply -f tests.dstack.yml --force -y
+        DSTACK_CLI_LOG_LEVEL=DEBUG HF_TOKEN=${{ secrets.HF_TOKEN }} dstack apply -f tests.dstack.yml --force -y

--- a/.github/workflows/run_tests_with_gpu.yml
+++ b/.github/workflows/run_tests_with_gpu.yml
@@ -34,4 +34,8 @@ jobs:
     
     - name: Run tests with GPU
       run: |
-        DSTACK_CLI_LOG_LEVEL=DEBUG HF_TOKEN=${{ secrets.HF_TOKEN }} dstack apply -f tests.dstack.yml --force -y
+        HF_TOKEN=${{ secrets.HF_TOKEN }} dstack apply -f tests.dstack.yml --force -y
+
+    - name: Extract pytest logs
+      run: |
+        dstack logs aana-tests | sed -n '/============================= test session starts ==============================/,$p'


### PR DESCRIPTION
This PR adds an extra step that extracts pytest logs from the full dstack logs so it's easier to review it.

Also, dstack got an update that fixes the disconnection issue when running in GitHub Actions that I reported. So now GPU tests are fully operational.

Example run: https://github.com/mobiusml/aana_sdk/actions/runs/11594576389/job/32281142696#step:7:1