### PR TITLE
Update Retryable Exceptions

### DIFF
--- a/aana/sdk.py
+++ b/aana/sdk.py
@@ -45,7 +45,7 @@ class AanaSDK:
             name (str, optional): The name of the application. Defaults to "app".
             migration_func (Callable | None): The migration function to run. Defaults to None.
             retryable_exceptions (list[Exception, str] | None): The exceptions that can be retried in the task queue.
-                                                                Defaults to ['InferenceException'].
+                                                                Defaults to ['InferenceException', 'ActorDiedError', 'OutOfMemoryError'].
         """
         self.name = name
         self.migration_func = migration_func
@@ -53,7 +53,11 @@ class AanaSDK:
         self.deployments: dict[str, Deployment] = {}
 
         if retryable_exceptions is None:
-            self.retryable_exceptions = [InferenceException]
+            self.retryable_exceptions = [
+                "InferenceException",
+                "ActorDiedError",
+                "OutOfMemoryError",
+            ]
         else:
             self.retryable_exceptions = retryable_exceptions
         # Convert exceptions to string if they are not already

--- a/aana/utils/core.py
+++ b/aana/utils/core.py
@@ -93,7 +93,9 @@ async def sleep_exponential_backoff(
         attempts (int): The number of attempts so far.
         jitter (bool): Whether to add jitter to the delay. Default is True.
     """
-    delay = min(initial_delay * (2**attempts), max_delay)
+    # Prevent overflow by using min(attempt, 32) since 2^32 is already huge
+    capped_attempt = min(attempts, 32)
+    delay = min(initial_delay * (2**capped_attempt), max_delay)
     # Full jitter
     delay_with_jitter = random.uniform(0, delay) if jitter else delay  # noqa: S311
     await asyncio.sleep(delay_with_jitter)


### PR DESCRIPTION
This pull request includes changes to improve the robustness and reliability of Aana SDK by updating retryable exceptions and preventing overflow in exponential backoff calculations.

### Improvements to retryable exceptions:

* [`aana/sdk.py`](diffhunk://#diff-9894ea7f31916f877102b6d32121e6a4a41dddd12ef41d0233e5888822df8a08L48-R60): Updated the default list of retryable exceptions to include `ActorDiedError` and `OutOfMemoryError` in addition to `InferenceException`.

### Enhancements to exponential backoff:

* [`aana/utils/core.py`](diffhunk://#diff-d4c034f8f14433299472b4070e731a3e3f3bc3215daa08a3b9b147c6f6ebed6dL96-R98): Modified the `sleep_exponential_backoff` function to cap the number of attempts at 32 to prevent overflow issues.