### PR TITLE
Ensure pytest logs are always extracted in GPU test workflow

### DIFF
--- a/.github/workflows/run_tests_with_gpu.yml
+++ b/.github/workflows/run_tests_with_gpu.yml
@@ -37,5 +37,6 @@ jobs:
         HF_TOKEN=${{ secrets.HF_TOKEN }} dstack apply -f tests.dstack.yml --force -y
 
     - name: Extract pytest logs
+      if: ${{ always() }}
       run: |
         dstack logs aana-tests | sed -n '/============================= test session starts ==============================/,$p'


### PR DESCRIPTION
Modify the GPU test workflow to ensure pytest logs are extracted regardless of the test outcome.