### PR TITLE
Adding timestamp related params to batched version 

### DIFF
--- a/aana/core/models/whisper.py
+++ b/aana/core/models/whisper.py
@@ -43,6 +43,10 @@ class WhisperParams(BaseModel):
             "Temperature for sampling. A single value or a sequence indicating fallback temperatures."
         ),
     )
+    without_timestamps: bool = Field(
+        default=False,
+        description="Whether to sample only text tokens in decoding.",
+    )
     word_timestamps: bool = Field(
         default=False, description="Whether to extract word-level timestamps."
     )
@@ -113,6 +117,13 @@ class BatchedWhisperParams(BaseModel):
         description=(
             "Temperature for sampling. A single value or a sequence indicating fallback temperatures."
         ),
+    )
+    without_timestamps: bool = Field(
+        default=True,
+        description="Whether to sample only text tokens in decoding. Set to 'False' to get phrase-level time stamps (eg. for subtitles)",
+    )
+    word_timestamps: bool = Field(
+        default=False, description="Whether to extract word-level timestamps."
     )
 
     @field_validator("temperature")


### PR DESCRIPTION
This enables using phrase-level output (for example in subtitles) in batched mode. Changes include adding `without_timestamps` and `word_timestamps` params to the batched version. For consistency, the parameter `without_timestamps` is also added to the sequential version.