### PR TITLE
Mitigate Health Check Timeouts for Blocking Operations in Deployments

### DIFF
--- a/aana/api/request_handler.py
+++ b/aana/api/request_handler.py
@@ -148,9 +148,10 @@ class RequestHandler:
                 TaskRepository(session).update_status(
                     task_id, TaskStatus.FAILED, 0, error
                 )
+        else:
+            return out
         finally:
             self.running_tasks.remove(task_id)
-        return out
 
     @app.get(
         "/tasks/get/{task_id}",

--- a/aana/deployments/pyannote_speaker_diarization_deployment.py
+++ b/aana/deployments/pyannote_speaker_diarization_deployment.py
@@ -47,7 +47,7 @@ class PyannoteSpeakerDiarizationConfig(BaseModel):
     model_config = ConfigDict(protected_namespaces=(*pydantic_protected_fields,))
 
 
-@serve.deployment
+@serve.deployment(health_check_timeout_s=180)
 class PyannoteSpeakerDiarizationDeployment(BaseDeployment):
     """Deployment to serve Pyannote Speaker Diarization (SD) models."""
 

--- a/aana/deployments/vad_deployment.py
+++ b/aana/deployments/vad_deployment.py
@@ -83,7 +83,7 @@ class VadConfig(BaseModel):
     model_config = ConfigDict(protected_namespaces=(*pydantic_protected_fields,))
 
 
-@serve.deployment
+@serve.deployment(health_check_timeout_s=180)
 class VadDeployment(BaseDeployment):
     """Deployment to serve VAD models."""
 

--- a/aana/deployments/whisper_deployment.py
+++ b/aana/deployments/whisper_deployment.py
@@ -139,7 +139,7 @@ class WhisperBatchOutput(TypedDict):
     transcription: list[AsrTranscription]
 
 
-@serve.deployment
+@serve.deployment(max_ongoing_requests=1)
 class WhisperDeployment(BaseDeployment):
     """Deployment to serve Whisper models from faster-whisper."""
 

--- a/aana/deployments/whisper_deployment.py
+++ b/aana/deployments/whisper_deployment.py
@@ -1,7 +1,11 @@
-from collections.abc import AsyncGenerator  # noqa: I001
+import asyncio
+import os
+from collections.abc import AsyncGenerator
 from enum import Enum
+from pathlib import Path
 from typing import Any, cast
 
+import nvidia.cudnn.lib
 import torch
 from faster_whisper import BatchedInferencePipeline, WhisperModel
 from pydantic import BaseModel, ConfigDict, Field
@@ -21,10 +25,6 @@ from aana.deployments.base_deployment import BaseDeployment, exception_handler
 from aana.exceptions.runtime import InferenceException
 
 # Workaround for CUDNN issue with cTranslate2:
-import os
-import nvidia.cudnn.lib
-from pathlib import Path
-
 cudnn_path = str(Path(nvidia.cudnn.lib.__file__).parent)
 os.environ["LD_LIBRARY_PATH"] = (
     cudnn_path + "/:" + os.environ.get("LD_LIBRARY_PATH", "")
@@ -162,7 +162,6 @@ class WhisperDeployment(BaseDeployment):
             model=self.model,
         )
 
-    @exception_handler
     async def transcribe(
         self, audio: Audio, params: WhisperParams | None = None
     ) -> WhisperOutput:
@@ -182,27 +181,12 @@ class WhisperDeployment(BaseDeployment):
         Raises:
             InferenceException: If the inference fails.
         """
-        if not params:
-            params = WhisperParams()
+        asr_segments = []
+        asr_transcription_info = None
+        async for output in self.transcribe_stream(audio, params):
+            asr_segments.extend(output["segments"])
+            asr_transcription_info = output["transcription_info"]
 
-        audio_array = audio.get_numpy()
-        if not audio_array.any():
-            # For silent audios/no audio tracks, return empty output with language as silence
-            return WhisperOutput(
-                segments=[],
-                transcription_info=AsrTranscriptionInfo(
-                    language="silence", language_confidence=1.0
-                ),
-                transcription=AsrTranscription(text=""),
-            )
-
-        try:
-            segments, info = self.model.transcribe(audio_array, **params.model_dump())
-        except Exception as e:
-            raise InferenceException(self.model_name) from e
-
-        asr_segments = [AsrSegment.from_whisper(seg) for seg in segments]
-        asr_transcription_info = AsrTranscriptionInfo.from_whisper(info)
         transcription = "".join([seg.text for seg in asr_segments])
         asr_transcription = AsrTranscription(text=transcription)
 
@@ -251,6 +235,7 @@ class WhisperDeployment(BaseDeployment):
 
             asr_transcription_info = AsrTranscriptionInfo.from_whisper(info)
             for segment in segments:
+                await asyncio.sleep(0)
                 asr_segments = [AsrSegment.from_whisper(segment)]
                 asr_transcription = AsrTranscription(text=segment.text)
 
@@ -345,6 +330,7 @@ class WhisperDeployment(BaseDeployment):
                 raise InferenceException(self.model_name) from e
             asr_transcription_info = AsrTranscriptionInfo.from_whisper(info)
             for segment in segments:
+                await asyncio.sleep(0)
                 asr_segments = [AsrSegment.from_whisper(segment)]
                 asr_transcription = AsrTranscription(text=segment.text)
                 yield WhisperOutput(


### PR DESCRIPTION
By default, Ray tries to check the health of the Ray deployment every 10 seconds (health_check_period_s) and if the health check doesn't happen within 30 seconds (health_check_timeout_s), Ray will consider the deployment unhealthy. After 3 consecutive health check failures (or timeouts), Ray will restart the deployment.

The checks are executed asynchronously. But if the deployment runs a blocking operation, the health check will be delayed and can timeout. This can lead to cases where the deployment is healthy, just slow and blocked by a long-running operation but Ray will consider it unhealthy and restart it.

To address this issue, we can add `await asyncio.sleep(0)` in the long-running operation where we want to yield control back to the event loop. This is what I've done in the whisper deployment to address the issue.

Some deployments just have one blocking operation and there is no place we can add `await asyncio.sleep(0)`. In this case, we can increase the health check timeout to a value that is higher than the expected time for the blocking operation to finish. This is what I've done in the VAD deployment and diarization deployment.
