### PR TITLE
Add Ray Dashboard Host and Port Parameters in Aana CLI

### DIFF
--- a/aana/cli.py
+++ b/aana/cli.py
@@ -51,7 +51,7 @@ def load_app(app_path: str):
     help="Address of the Ray cluster (default: auto)",
 )
 @click.option(
-    "--ray-dashboard-address",
+    "--ray-dashboard-host",
     default="127.0.0.1",
     type=str,
     help=(
@@ -77,7 +77,7 @@ def deploy(
     port: int,
     hide_logs: bool,
     ray_address: str,
-    ray_dashboard_address: str,
+    ray_dashboard_host: str,
     ray_dashboard_port: int,
     skip_migrations: bool,
 ):
@@ -94,7 +94,7 @@ def deploy(
         host=host,
         show_logs=show_logs,
         address=ray_address,
-        dashboard_address=ray_dashboard_address,
+        dashboard_host=ray_dashboard_host,
         dashboard_port=ray_dashboard_port,
     )
     with contextlib.suppress(

--- a/aana/cli.py
+++ b/aana/cli.py
@@ -51,6 +51,22 @@ def load_app(app_path: str):
     help="Address of the Ray cluster (default: auto)",
 )
 @click.option(
+    "--ray-dashboard-address",
+    default="127.0.0.1",
+    type=str,
+    help=(
+        "The host to bind the dashboard server to. Can either be "
+        "localhost (127.0.0.1) or 0.0.0.0 (available from all interfaces). "
+        "By default, this is set to localhost to prevent access from external machines."
+    ),
+)
+@click.option(
+    "--ray-dashboard-port",
+    default=8265,
+    type=int,
+    help="The port to bind the dashboard server to (default: 8265)",
+)
+@click.option(
     "--skip-migrations",
     is_flag=True,
     help="Skip migrations before deploying",
@@ -61,6 +77,8 @@ def deploy(
     port: int,
     hide_logs: bool,
     ray_address: str,
+    ray_dashboard_address: str,
+    ray_dashboard_port: int,
     skip_migrations: bool,
 ):
     """Deploy the application.
@@ -71,7 +89,14 @@ def deploy(
     if not skip_migrations:
         aana_app.migrate()
     show_logs = not hide_logs
-    aana_app.connect(port=port, host=host, show_logs=show_logs, address=ray_address)
+    aana_app.connect(
+        port=port,
+        host=host,
+        show_logs=show_logs,
+        address=ray_address,
+        dashboard_address=ray_dashboard_address,
+        dashboard_port=ray_dashboard_port,
+    )
     with contextlib.suppress(
         DeploymentException
     ):  # we have a nice error message for this

--- a/aana/sdk.py
+++ b/aana/sdk.py
@@ -106,9 +106,6 @@ class AanaSDK:
                 address=address,
                 ignore_reinit_error=True,
                 log_to_driver=show_logs,
-                include_dashboard=True,
-                dashboard_host=dashboard_host,
-                dashboard_port=dashboard_port,
             )
         except ConnectionError:
             # If connection fails, start a new Ray cluster and serve instance
@@ -117,6 +114,9 @@ class AanaSDK:
                 log_to_driver=show_logs,
                 num_cpus=num_cpus,
                 num_gpus=num_gpus,
+                include_dashboard=True,
+                dashboard_host=dashboard_host,
+                dashboard_port=dashboard_port,
             )
 
         serve_status = serve.status()


### PR DESCRIPTION
Introduce command-line options to specify the Ray dashboard's address and port for Aana CLI.