### PR TITLE
Add Torch Cache Clearing to Health Check for vLLM and Whisper Deployments

### DIFF
--- a/aana/deployments/vllm_deployment.py
+++ b/aana/deployments/vllm_deployment.py
@@ -2,6 +2,7 @@ import base64
 from collections.abc import AsyncGenerator
 from typing import Any
 
+import torch
 from outlines.integrations.vllm import JSONLogitsProcessor, RegexLogitsProcessor
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 from ray import serve
@@ -129,9 +130,10 @@ class VLLMDeployment(BaseDeployment):
         self.model_config = await self.engine.get_model_config()
 
     async def check_health(self):
-        """Check the health of the deployment."""
+        """Check the health of the deployment and clear torch cache to prevent memory leaks."""
         if self.engine:
             await self.engine.check_health()
+            torch.cuda.empty_cache()
 
         await super().check_health()
 

--- a/aana/deployments/whisper_deployment.py
+++ b/aana/deployments/whisper_deployment.py
@@ -162,6 +162,11 @@ class WhisperDeployment(BaseDeployment):
             model=self.model,
         )
 
+    async def check_health(self):
+        """Check the health of the deployment and clear torch cache to prevent memory leaks."""
+        torch.cuda.empty_cache()
+        await super().check_health()
+
     async def transcribe(
         self, audio: Audio, params: WhisperParams | None = None
     ) -> WhisperOutput:


### PR DESCRIPTION
Incorporate torch cache clearing into the health check to prevent GPU memory leaks in vLLM and Whisper deployments.

Issue: https://github.com/mobiusml/aana_episodic_retrieval/issues/17