### PR TITLE
Add Sequential Deployment Option

### DIFF
--- a/aana/cli.py
+++ b/aana/cli.py
@@ -71,6 +71,11 @@ def load_app(app_path: str):
     is_flag=True,
     help="Skip migrations before deploying",
 )
+@click.option(
+    "--sequential-deploy",
+    is_flag=True,
+    help="Deploy the application's deployments sequentially",
+)
 def deploy(
     app_path: str,
     host: str,
@@ -80,6 +85,7 @@ def deploy(
     ray_dashboard_host: str,
     ray_dashboard_port: int,
     skip_migrations: bool,
+    sequential_deploy: bool,
 ):
     """Deploy the application.
 
@@ -100,7 +106,7 @@ def deploy(
     with contextlib.suppress(
         DeploymentException
     ):  # we have a nice error message for this
-        aana_app.deploy(blocking=True)
+        aana_app.deploy(blocking=True, sequential=sequential_deploy)
 
 
 @cli.command()

--- a/aana/sdk.py
+++ b/aana/sdk.py
@@ -355,11 +355,12 @@ class AanaSDK:
 
             time.sleep(1)  # Wait for 1 second before checking again
 
-    def deploy(self, blocking: bool = False):
+    def deploy(self, blocking: bool = False, sequential: bool = False):
         """Deploy the application with the registered endpoints and deployments.
 
         Args:
             blocking (bool, optional): If True, the function will block until interrupted. Defaults to False.
+            sequential (bool, optional): If True, the deployments will be deployed sequentially. Defaults to False.
         """
         try:
             for deployment_name in self.deployments:
@@ -369,6 +370,8 @@ class AanaSDK:
                     route_prefix=f"/{deployment_name}",
                     _blocking=False,
                 )
+                if sequential:
+                    self.wait_for_deployment()
 
             serve.api._run(
                 self.get_main_app(),


### PR DESCRIPTION
Introduce a sequential deployment option in the CLI and SDK to allow deployments to start one after another. 

This is helpful for vLLM deployment that checks GPU memory while startup. If any other models start on GPU while vLLM starts it may lead to wrong calculations of KV cache size and triggers deployment failure. Usually it's not an issue because if that happens the deployment restarts and second (or third) try is successful.

This option leads to sequential deployment startup which is slower but safer. In my experience it's around 3x slower when models are already downloaded, it would be even slower with empty model cache.