### PR TITLE
Refactor File Uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,75 @@ aana_app.deploy()   # Deploys the application.
 
 All you need to do is define the deployments and endpoints you want to use in your application, and Aana SDK will take care of the rest.
 
+
+## API
+
+Aana SDK uses form data for API requests, which allows sending both binary data and structured fields in a single request. The request body is sent as a JSON string in the `body` field, and any binary data is sent as files.
+
+### Making API Requests
+
+You can send requests to the SDK endpoints with only structured data or a combination of structured data and binary data.
+
+#### Only Structured Data
+When your request includes only structured data, you can send it as a JSON string in the `body` field.
+
+- **cURL Example:**
+    ```bash
+    curl http://127.0.0.1:8000/endpoint \
+        -F body='{"input": "data", "param": "value"}'
+    ```
+
+- **Python Example:**
+    ```python
+    import json, requests
+
+    url = "http://127.0.0.1:8000/endpoint"
+    body = {
+        "input": "data",
+        "param": "value"
+    }
+
+    response = requests.post(
+        url,
+        data={"body": json.dumps(body)}
+    )
+
+    print(response.json())
+    ```
+
+#### With Binary Data
+When your request includes binary files (images, audio, etc.), you can send them as files in the request and include the names of the files in the `body` field as a reference.
+
+For example, if you want to send an image, you can use [`aana.core.models.image.ImageInput`](https://mobiusml.github.io/aana_sdk/reference/models/media/#aana.core.models.ImageInput) as the input type that supports binary data upload. The `content` field in the input type should be set to the name of the file you are sending. 
+
+- **cURL Example:**
+    ```bash
+    curl http://127.0.0.1:8000/process_images \
+        -H "Content-Type: multipart/form-data" \
+        -F body='{"image": {"content": "file1"}}' \
+        -F file1="@image.jpeg"
+    ```
+
+- **Python Example:**
+    ```python
+    import json, requests 
+
+    url = "http://127.0.0.1:8000/process_images"
+    body = {
+        "image": {"content": "file1"}
+    }
+    with open("image.jpeg", "rb") as file:
+        files = {"file1": file}
+
+        response = requests.post(
+            url,
+            data={"body": json.dumps(body)},
+            files=files
+        )
+
+        print(response.text)
+    ```
+
 ## Serve Config Files
 
 The [Serve Config Files](https://docs.ray.io/en/latest/serve/production-guide/config.html#serve-config-files) is the recommended way to deploy and update your applications in production. Aana SDK provides a way to build the Serve Config Files for the Aana applications. See the [Serve Config Files documentation](https://mobiusml.github.io/aana_sdk/pages/serve_config_files/) on how to build and deploy the applications using the Serve Config Files.

--- a/aana/api/api_generation.py
+++ b/aana/api/api_generation.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from inspect import isasyncgenfunction
 from typing import Annotated, Any, get_origin
 
-from fastapi import FastAPI, File, Form, Query, Request, UploadFile
+from fastapi import FastAPI, Form, Query, Request
 from fastapi.responses import StreamingResponse
 from pydantic import ConfigDict, Field, ValidationError, create_model
 from pydantic.main import BaseModel

--- a/aana/api/api_generation.py
+++ b/aana/api/api_generation.py
@@ -16,9 +16,6 @@ from aana.api.exception_handler import custom_exception_handler
 from aana.api.responses import AanaJSONResponse
 from aana.configs.settings import settings as aana_settings
 from aana.core.models.exception import ExceptionResponseModel
-from aana.exceptions.runtime import (
-    MultipleFileUploadNotAllowed,
-)
 from aana.storage.repository.task import TaskRepository
 from aana.storage.session import get_session
 
@@ -31,19 +28,6 @@ def get_default_values(func):
         for k, v in signature.parameters.items()
         if v.default is not inspect.Parameter.empty
     }
-
-
-@dataclass
-class FileUploadField:
-    """Class used to represent a file upload field.
-
-    Attributes:
-        name (str): Name of the field.
-        description (str): Description of the field.
-    """
-
-    name: str
-    description: str
 
 
 @dataclass
@@ -106,14 +90,12 @@ class Endpoint:
         RequestModel = self.get_request_model()
         ResponseModel = self.get_response_model()
 
-        file_upload_field = self.__get_file_upload_field()
         if self.event_handlers:
             for handler in self.event_handlers:
                 event_manager.register_handler_for_events(handler, [self.path])
 
         route_func = self.__create_endpoint_func(
             RequestModel=RequestModel,
-            file_upload_field=file_upload_field,
             event_manager=event_manager,
         )
 
@@ -230,39 +212,6 @@ class Endpoint:
             model_name, **output_fields, __config__=ConfigDict(extra="forbid")
         )
 
-    def __get_file_upload_field(self) -> FileUploadField | None:
-        """Get the file upload field for the endpoint.
-
-        Returns:
-            Optional[FileUploadField]: File upload field or None if not found.
-
-        Raises:
-            MultipleFileUploadNotAllowed: If multiple inputs require file upload.
-        """
-        file_upload_field = None
-        for arg_name, arg_type in self.run.__annotations__.items():
-            if arg_name == "return":
-                continue
-
-            # check if pydantic model has file_upload field and it's set to True
-            if isinstance(arg_type, type) and issubclass(arg_type, BaseModel):
-                file_upload_enabled = arg_type.model_config.get("file_upload", False)
-                file_upload_description = arg_type.model_config.get(
-                    "file_upload_description", ""
-                )
-            else:
-                file_upload_enabled = False
-                file_upload_description = ""
-
-            if file_upload_enabled and file_upload_field is None:
-                file_upload_field = FileUploadField(
-                    name=arg_name, description=file_upload_description
-                )
-            elif file_upload_enabled and file_upload_field is not None:
-                # raise an exception if multiple inputs require file upload
-                raise MultipleFileUploadNotAllowed(arg_name)
-        return file_upload_field
-
     @classmethod
     def is_streaming_response(cls) -> bool:
         """Check if the endpoint returns a streaming response.
@@ -275,7 +224,6 @@ class Endpoint:
     def __create_endpoint_func(  # noqa: C901
         self,
         RequestModel: type[BaseModel],
-        file_upload_field: FileUploadField | None = None,
         event_manager: EventManager | None = None,
     ) -> Callable:
         """Create a function for routing an endpoint."""
@@ -283,7 +231,7 @@ class Endpoint:
         bound_path = self.path
 
         async def route_func_body(  # noqa: C901
-            body: str, files: dict[str, StarletteUploadFile] | None = None, defer=False
+            body: str, files: dict[str, bytes] | None = None, defer=False
         ):
             if not self.initialized:
                 await self.initialize()
@@ -296,18 +244,10 @@ class Endpoint:
 
             # if the input requires file upload, add the files to the data
             if files:
-                # files_as_bytes = [await file.read() for file in files]
-                # getattr(data, file_upload_field.name).set_files(files)
-                # breakpoint()
-                # Check if any field have set_files method
                 for field_name in data.model_fields:
                     field_value = getattr(data, field_name)
                     if hasattr(field_value, "set_files"):
-                        await field_value.set_files(files)
-            elif files and not file_upload_field:
-                raise ValueError(  # noqa: TRY003
-                    "This endpoint does not accept file uploads."
-                )
+                        field_value.set_files(files)
 
             # We have to do this instead of data.dict() because
             # data.dict() will convert all nested models to dicts
@@ -347,44 +287,21 @@ class Endpoint:
                     return custom_exception_handler(None, e)
                 return AanaJSONResponse(content=output)
 
-        if file_upload_field:
-            files = File(None, description=file_upload_field.description)
-        else:
-            files = File(
-                None, description="This endpoint does not accept file uploads."
-            )
-
         async def route_func(
             request: Request,
             body: str = Form(...),
-            # files: list[UploadFile] = files,
             defer: bool = Query(
                 description="Defer execution of the endpoint to the task queue.",
                 default=False,
                 include_in_schema=aana_settings.task_queue.enabled,
             ),
         ):
-            # Log the headers
-            print(f"Headers: {request.headers}")
-
-            # Log the form data body
             form_data = await request.form()
-            print(f"Form Data: {form_data}")
 
-            # Extract the files from the form data (fields with type UploadFile)
-            files = {}
+            files: dict[str, bytes] = {}
             for field_name, field_value in form_data.items():
                 if isinstance(field_value, StarletteUploadFile):
-                    files[field_name] = field_value
-
-            print(f"Files: {files}")
-
-            # breakpoint()
-
-            # # Log the uploaded files
-            # uploaded_files = [file.filename for file in files]
-            # print(f"Uploaded Files: {uploaded_files}")
-
+                    files[field_name] = await field_value.read()
             return await route_func_body(body=body, files=files, defer=defer)
 
         return route_func

--- a/aana/core/models/image.py
+++ b/aana/core/models/image.py
@@ -13,11 +13,8 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
-    ValidationError,
     model_validator,
 )
-from pydantic_core import InitErrorDetails
-from starlette.datastructures import UploadFile as StarletteUploadFile
 from typing_extensions import Self
 
 from aana.configs.settings import settings

--- a/aana/core/models/video.py
+++ b/aana/core/models/video.py
@@ -15,10 +15,8 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
-    ValidationError,
     model_validator,
 )
-from pydantic_core import InitErrorDetails
 from typing_extensions import Self
 
 from aana.core.models.base import BaseListModel

--- a/aana/exceptions/runtime.py
+++ b/aana/exceptions/runtime.py
@@ -2,12 +2,16 @@ from aana.exceptions.core import BaseException
 
 __all__ = [
     "InferenceException",
-    "MultipleFileUploadNotAllowed",
     "PromptTooLongException",
     "EndpointNotFoundException",
     "TooManyRequestsException",
     "HandlerAlreadyRegisteredException",
     "HandlerNotRegisteredException",
+    "UploadedFileNotFound",
+    "DeploymentException",
+    "InsufficientResources",
+    "FailedDeployment",
+    "EmptyMigrationsException",
 ]
 
 
@@ -35,27 +39,6 @@ class InferenceException(BaseException):
         """
         # TODO: check if there is a better way to do this
         return (self.__class__, (self.model_name,))
-
-
-class MultipleFileUploadNotAllowed(BaseException):
-    """Exception raised when multiple inputs require file upload.
-
-    Attributes:
-        input_name -- name of the input
-    """
-
-    def __init__(self, input_name: str):
-        """Initialize the exception.
-
-        Args:
-            input_name (str): name of the input that caused the exception
-        """
-        super().__init__(input_name=input_name)
-        self.input_name = input_name
-
-    def __reduce__(self):
-        """Used for pickling."""
-        return (self.__class__, (self.input_name,))
 
 
 class PromptTooLongException(BaseException):
@@ -176,3 +159,20 @@ class FailedDeployment(DeploymentException):
     """Exception raised when there is an error during deployment."""
 
     pass
+
+
+class UploadedFileNotFound(Exception):
+    """Exception raised when the uploaded file is not found."""
+
+    def __init__(self, filename: str):
+        """Initialize the exception.
+
+        Args:
+            filename (str): the name of the file that was not found
+        """
+        super().__init__()
+        self.filename = filename
+
+    def __reduce__(self):
+        """Used for pickling."""
+        return (self.__class__, (self.filename,))

--- a/aana/tests/units/test_api_generation.py
+++ b/aana/tests/units/test_api_generation.py
@@ -6,31 +6,12 @@ import pytest
 from pydantic import BaseModel, ConfigDict, Field
 
 from aana.api.api_generation import Endpoint
-from aana.exceptions.runtime import UploadedFileNotFound
 
 
 class InputModel(BaseModel):
     """Model for a text input."""
 
     input: str = Field(..., description="Input text")
-    model_config = ConfigDict(extra="forbid")
-
-
-class FileUploadModel(BaseModel):
-    """Model for a file upload input."""
-
-    content: str | None = Field(
-        None,
-        description="The name of the file to upload.",
-    )
-    _file: bytes | None = None
-
-    def set_files(self, files: dict[str, bytes]):
-        """Set files."""
-        if self.content and not self._file:
-            raise UploadedFileNotFound(self.content)
-        self._file = files[self.content]
-
     model_config = ConfigDict(extra="forbid")
 
 
@@ -46,24 +27,6 @@ class TestEndpoint(Endpoint):
     async def run(self, input_data: InputModel) -> TestEndpointOutput:
         """Run the endpoint."""
         return {"output": input_data.input}
-
-
-class TestFileUploadEndpoint(Endpoint):
-    """Test endpoint for file uploads."""
-
-    async def run(self, input_data: FileUploadModel) -> TestEndpointOutput:
-        """Run the endpoint."""
-        return {"output": "file uploaded"}
-
-
-class TestMultipleFileUploadEndpoint(Endpoint):
-    """Test endpoint for multiple file uploads."""
-
-    async def run(
-        self, input_data: FileUploadModel, input_data2: FileUploadModel
-    ) -> TestEndpointOutput:
-        """Run the endpoint."""
-        return {"output": "file uploaded"}
 
 
 class TestEndpointMissingReturn(Endpoint):
@@ -119,15 +82,6 @@ def test_get_response_model():
 
     # Check that the response fields have the correct types
     assert ResponseModel.model_fields["output"].annotation == str
-
-
-# def test_get_file_upload_field_multiple_file_uploads():
-#     """Test the __get_file_upload_field function with multiple file uploads."""
-#     endpoint = TestMultipleFileUploadEndpoint(
-#         name="test_endpoint",
-#         summary="Test endpoint",
-#         path="/test_endpoint",
-#     )
 
 
 def test_get_response_model_missing_return():

--- a/aana/tests/units/test_app_upload.py
+++ b/aana/tests/units/test_app_upload.py
@@ -1,0 +1,90 @@
+# ruff: noqa: S101, S113
+import io
+import json
+from typing import TypedDict
+
+import requests
+from pydantic import BaseModel, ConfigDict, Field
+
+from aana.api.api_generation import Endpoint
+from aana.exceptions.runtime import UploadedFileNotFound
+
+
+class FileUploadModel(BaseModel):
+    """Model for a file upload input."""
+
+    content: str | None = Field(
+        None,
+        description="The name of the file to upload.",
+    )
+    _file: bytes | None = None
+
+    def set_files(self, files: dict[str, bytes]):
+        """Set files."""
+        if self.content:
+            if self.content not in files:
+                raise UploadedFileNotFound(self.content)
+            self._file = files[self.content]
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class FileUploadEndpointOutput(TypedDict):
+    """The output of the file upload endpoint."""
+
+    text: str
+
+
+class FileUploadEndpoint(Endpoint):
+    """File upload endpoint."""
+
+    async def run(self, file: FileUploadModel) -> FileUploadEndpointOutput:
+        """Upload a file.
+
+        Args:
+            file (FileUploadModel): The file to upload
+
+        Returns:
+            FileUploadEndpointOutput: The uploaded file
+        """
+        file = file._file
+        return {"text": file.decode()}
+
+
+deployments = []
+
+endpoints = [
+    {
+        "name": "file_upload",
+        "path": "/file_upload",
+        "summary": "Upload a file",
+        "endpoint_cls": FileUploadEndpoint,
+    }
+]
+
+
+def test_file_upload_app(create_app):
+    """Test the app with a file upload endpoint."""
+    aana_app = create_app(deployments, endpoints)
+
+    port = aana_app.port
+    route_prefix = ""
+
+    # Check that the server is ready
+    response = requests.get(f"http://localhost:{port}{route_prefix}/api/ready")
+    assert response.status_code == 200
+    assert response.json() == {"ready": True}
+
+    # Test lowercase endpoint
+    # data = {"content": "file.txt"}
+    data = {"file": {"content": "file.txt"}}
+    file = b"Hello world! This is a test."
+    files = {"file.txt": io.BytesIO(file)}
+    response = requests.post(
+        f"http://localhost:{port}{route_prefix}/file_upload",
+        data={"body": json.dumps(data)},
+        files=files,
+    )
+    assert response.status_code == 200, response.text
+    text = response.json().get("text")
+    assert text == file.decode()

--- a/aana/tests/units/test_image_input.py
+++ b/aana/tests/units/test_image_input.py
@@ -216,7 +216,6 @@ def test_imagelistinput():
 
 def test_imagelistinput_set_files():
     """Test that the files can be set for the images."""
-    # files = [b"image data 1", b"image data 2"]
     files = {
         "file": b"image data 1",
         "numpy_file": b"image data 2",

--- a/aana/utils/json.py
+++ b/aana/utils/json.py
@@ -36,15 +36,22 @@ def json_serializer_default(obj: object) -> object:
         return str(obj)
     if isinstance(obj, type):
         return str(type)
+    if isinstance(obj, bytes):
+        return obj.decode()
 
     from aana.core.models.media import Media
+
     if isinstance(obj, Media):
         return str(obj)
 
     raise TypeError(type(obj))
 
 
-def jsonify(data: Any, option: int | None = orjson.OPT_SERIALIZE_NUMPY | orjson.OPT_SORT_KEYS, as_bytes: bool = False) -> str | bytes:
+def jsonify(
+    data: Any,
+    option: int | None = orjson.OPT_SERIALIZE_NUMPY | orjson.OPT_SORT_KEYS,
+    as_bytes: bool = False,
+) -> str | bytes:
     """Serialize content using orjson.
 
     Args:

--- a/docs/index.md
+++ b/docs/index.md
@@ -315,3 +315,73 @@ aana_app.deploy()   # Deploys the application.
 
 All you need to do is define the deployments and endpoints you want to use in your application, and Aana SDK will take care of the rest.
 
+
+## API
+
+Aana SDK uses form data for API requests, which allows sending both binary data and structured fields in a single request. The request body is sent as a JSON string in the `body` field, and any binary data is sent as files.
+
+### Making API Requests
+
+You can send requests to the SDK endpoints with only structured data or a combination of structured data and binary data.
+
+#### Only Structured Data
+When your request includes only structured data, you can send it as a JSON string in the `body` field.
+
+- **cURL Example:**
+    ```bash
+    curl http://127.0.0.1:8000/endpoint \
+        -F body='{"input": "data", "param": "value"}'
+    ```
+
+- **Python Example:**
+    ```python
+    import json, requests
+
+    url = "http://127.0.0.1:8000/endpoint"
+    body = {
+        "input": "data",
+        "param": "value"
+    }
+
+    response = requests.post(
+        url,
+        data={"body": json.dumps(body)}
+    )
+
+    print(response.json())
+    ```
+
+#### With Binary Data
+When your request includes binary files (images, audio, etc.), you can send them as files in the request and include the names of the files in the `body` field as a reference.
+
+For example, if you want to send an image, you can use [`aana.core.models.image.ImageInput`](reference/models/media.md#aana.core.models.ImageInput) as the input type that supports binary data upload. The `content` field in the input type should be set to the name of the file you are sending.
+
+You can send multiple files in a single request by including multiple files in the request and referencing them in the `body` field even if they are of different types.
+
+- **cURL Example:**
+    ```bash
+    curl http://127.0.0.1:8000/process_images \
+        -H "Content-Type: multipart/form-data" \
+        -F body='{"image": {"content": "file1"}}' \
+        -F file1="@image.jpeg"
+    ```
+
+- **Python Example:**
+    ```python
+    import json, requests 
+
+    url = "http://127.0.0.1:8000/process_images"
+    body = {
+        "image": {"content": "file1"}
+    }
+    with open("image.jpeg", "rb") as file:
+        files = {"file1": file}
+
+        response = requests.post(
+            url,
+            data={"body": json.dumps(body)},
+            files=files
+        )
+
+        print(response.text)
+    ```


### PR DESCRIPTION
Refactor file upload to allow reference uploaded files. That streamlines file uploading functionality and allows more flexible use of file uploads Update the documentation to include examples for API requests involving structured and binary data.