### PR TITLE
Update VAD model in VAD deployment

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -43,4 +43,5 @@ jobs:
     - name: Test with pytest
       env:
         USE_DEPLOYMENT_CACHE: True
+        HF_TOKEN: ${{ secrets.HF_TOKEN }}
       run: poetry run pytest -vv

--- a/aana/deployments/vad_deployment.py
+++ b/aana/deployments/vad_deployment.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Any, TypedDict
 
 import torch
+from huggingface_hub.utils import GatedRepoError
 from pyannote.audio import Model
 from pydantic import BaseModel, ConfigDict, Field
 from ray import serve
@@ -13,7 +14,6 @@ from aana.core.models.vad import VadParams, VadSegment
 from aana.deployments.base_deployment import BaseDeployment, exception_handler
 from aana.exceptions.runtime import InferenceException
 from aana.processors.vad import BinarizeVadScores, VoiceActivitySegmentation
-from aana.utils.download import download_model
 
 
 @dataclass
@@ -45,7 +45,7 @@ class VadConfig(BaseModel):
     """The configuration for the vad deployment.
 
     Attributes:
-        model (str): The model url.
+        model_id (str): The model id.
         onset (float): The onset threshold. Defaults to 0.500.
         offset (float): The offset threshold. Defaults to 0.363.
         min_duration_on (float): The minimum duration for voice activity. Defaults to 0.1.
@@ -53,8 +53,9 @@ class VadConfig(BaseModel):
         sample_rate (int): The sample rate of the audio. Defaults to 16000.
     """
 
-    model: str = Field(
-        description="The VAD model url.",
+    model_id: str = Field(
+        default="pyannote/segmentation",
+        description="The VAD model id.",
     )
 
     # default_parameters for the model on initialization:
@@ -111,15 +112,20 @@ class VadDeployment(BaseDeployment):
         if torch.cuda.is_available():
             torch.cuda.manual_seed_all(42)
 
-        # model hash for vad_model
-        model_hash = str(config_obj.model).split("/")[-2]
-        self.filepath = download_model(config_obj.model, model_hash)
+        self.model_id = config_obj.model_id
+        try:
+            # load model using pyannote Pipeline
+            self.segmentation_model = Model.from_pretrained(
+                self.model_id, use_auth_token=None
+            )
+            self.vad_pipeline = VoiceActivitySegmentation(
+                segmentation=self.segmentation_model, device=torch.device(self.device)
+            )
 
-        self.vad_model = Model.from_pretrained(self.filepath, use_auth_token=None)
-        # vad_pipeline
-        self.vad_pipeline = VoiceActivitySegmentation(
-            segmentation=self.vad_model, device=torch.device(self.device)
-        )
+        except Exception as e:
+            raise GatedRepoError(
+                message=f"This repository is private and requires a token to accept user conditions and access models in {self.model_id} pipeline."
+            ) from e
         self.vad_pipeline.instantiate(self.hyperparameters)
 
     async def __merge(
@@ -207,7 +213,7 @@ class VadDeployment(BaseDeployment):
         try:
             vad_segments = self.vad_pipeline(vad_input)
         except Exception as e:
-            raise InferenceException(self.filepath.name) from e
+            raise InferenceException(self.model_id) from e
 
         return vad_segments
 

--- a/aana/tests/deployments/test_vad_deployment.py
+++ b/aana/tests/deployments/test_vad_deployment.py
@@ -19,10 +19,7 @@ deployments = [
             max_ongoing_requests=1000,
             ray_actor_options={"num_gpus": 0},
             user_config=VadConfig(
-                model=(
-                    "https://whisperx.s3.eu-west-2.amazonaws.com/model_weights/segmentation/"
-                    "0b5b3216d60a2d32fc086b47ea8c67589aaeb26b7e07fcbe620d6d0b83e209ea/pytorch_model.bin"
-                ),
+                model_id="pyannote/segmentation",
                 onset=0.5,
                 sample_rate=16000,
             ).model_dump(mode="json"),


### PR DESCRIPTION
The current model path is moved out from the  S3 location, so it is wiser to use the same pyannote VAD model available in HF repo.
-Changes in deployment and test files
-Changes in Git workflow to add HF_TOKEN