### PR TITLE
Implement API key validation and LAGO API integration

### DIFF
--- a/aana/api/api_generation.py
+++ b/aana/api/api_generation.py
@@ -309,7 +309,16 @@ class Endpoint:
 
             # Add api_key_info to the body if API service is enabled
             if aana_settings.api_service.enabled:
-                body["api_key_info"] = request.state.api_key_info
+                api_key_field = next(
+                    (
+                        field_name
+                        for field_name, field in RequestModel.model_fields.items()
+                        if field.annotation is ApiKey
+                    ),
+                    None,
+                )
+                if api_key_field:
+                    body[api_key_field] = request.state.api_key_info
 
             # Parse files from the form data
             files: dict[str, bytes] = {}

--- a/aana/api/api_generation.py
+++ b/aana/api/api_generation.py
@@ -1,9 +1,12 @@
 import inspect
+import time
+import uuid
 from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass
 from inspect import isasyncgenfunction
 from typing import Annotated, Any, get_origin
 
+import orjson
 from fastapi import FastAPI, Form, Query, Request
 from fastapi.responses import StreamingResponse
 from pydantic import ConfigDict, Field, ValidationError, create_model
@@ -15,6 +18,7 @@ from aana.api.event_handlers.event_manager import EventManager
 from aana.api.exception_handler import custom_exception_handler
 from aana.api.responses import AanaJSONResponse
 from aana.configs.settings import settings as aana_settings
+from aana.core.models.api_service import ApiKey
 from aana.core.models.exception import ExceptionResponseModel
 from aana.storage.repository.task import TaskRepository
 from aana.storage.session import get_session
@@ -231,7 +235,9 @@ class Endpoint:
         bound_path = self.path
 
         async def route_func_body(  # noqa: C901
-            body: str, files: dict[str, bytes] | None = None, defer=False
+            body: dict[str, Any],
+            files: dict[str, bytes] | None = None,
+            defer=False,
         ):
             if not self.initialized:
                 await self.initialize()
@@ -240,7 +246,7 @@ class Endpoint:
                 event_manager.handle(bound_path, defer=defer)
 
             # parse form data as a pydantic model and validate it
-            data = RequestModel.model_validate_json(body)
+            data = RequestModel.model_validate(body)
 
             # if the input requires file upload, add the files to the data
             if files:
@@ -298,13 +304,55 @@ class Endpoint:
         ):
             form_data = await request.form()
 
+            # Parse json data from the body
+            body = orjson.loads(body)
+
+            # Add api_key_info to the body if API service is enabled
+            if aana_settings.api_service.enabled:
+                body["api_key_info"] = request.state.api_key_info
+
+            # Parse files from the form data
             files: dict[str, bytes] = {}
             for field_name, field_value in form_data.items():
                 if isinstance(field_value, StarletteUploadFile):
                     files[field_name] = await field_value.read()
+
             return await route_func_body(body=body, files=files, defer=defer)
 
         return route_func
+
+    def send_usage_event(
+        self, api_key: ApiKey, metric: str, properties: dict[str, Any]
+    ):
+        """Send a usage event to the LAGO API service.
+
+        Args:
+            api_key (ApiKey): The API key information.
+            metric (str): The metric code.
+            properties (dict): The properties of the event (usage data, e.g. {"count": 10}).
+        """
+        from lago_python_client.client import Client
+        from lago_python_client.exceptions import LagoApiError
+        from lago_python_client.models import Event
+
+        client = Client(
+            api_key=aana_settings.api_service.lago_api_key,
+            api_url=aana_settings.api_service.lago_url,
+        )
+
+        event = Event(
+            transaction_id=str(uuid.uuid4()),
+            code=metric,
+            external_subscription_id=api_key.subscription_id,
+            timestamp=time.time(),
+            properties=properties,
+        )
+
+        try:
+            client.events.create(event)
+        except LagoApiError as e:
+            # TODO: Log the error properly
+            print("Unable to send usage event: ", e)
 
 
 def add_custom_schemas_to_openapi_schema(

--- a/aana/api/app.py
+++ b/aana/api/app.py
@@ -1,12 +1,47 @@
-from fastapi import FastAPI
+
+from fastapi import FastAPI, Request
 from pydantic import ValidationError
 
 from aana.api.exception_handler import (
     aana_exception_handler,
     validation_exception_handler,
 )
+from aana.configs.settings import settings as aana_settings
+from aana.exceptions.api_service import (
+    ApiKeyNotFound,
+    ApiKeyNotProvided,
+    InactiveSubscription,
+)
+from aana.storage.models.api_key import ApiKeyEntity
+from aana.storage.session import get_session
 
 app = FastAPI()
 
 app.add_exception_handler(ValidationError, validation_exception_handler)
 app.add_exception_handler(Exception, aana_exception_handler)
+
+
+@app.middleware("http")
+async def api_key_check(request: Request, call_next):
+    """Middleware to check the API key and subscription status."""
+    if aana_settings.api_service.enabled:
+        api_key = request.headers.get("x-api-key")
+
+        if not api_key:
+            raise ApiKeyNotProvided()
+
+        with get_session() as session:
+            api_key_info = (
+                session.query(ApiKeyEntity).filter_by(api_key=api_key).first()
+            )
+
+            if not api_key_info:
+                raise ApiKeyNotFound(key=api_key)
+
+            if not api_key_info.is_subscription_active:
+                raise InactiveSubscription(key=api_key)
+
+            request.state.api_key_info = api_key_info.to_dict()
+
+    response = await call_next(request)
+    return response

--- a/aana/configs/settings.py
+++ b/aana/configs/settings.py
@@ -48,7 +48,7 @@ class ApiServiceSettings(BaseModel):
         lago_api_key (str): The API key for the LAGO API service.
     """
 
-    enabled: bool = True
+    enabled: bool = False
     lago_url: str | None = None
     lago_api_key: str | None = None
 

--- a/aana/core/models/api_service.py
+++ b/aana/core/models/api_service.py
@@ -1,0 +1,11 @@
+
+from pydantic import BaseModel
+
+
+class ApiKey(BaseModel):
+    """Pydantic model for API key entity."""
+
+    api_key: str
+    user_id: str
+    subscription_id: str
+    is_subscription_active: bool

--- a/aana/core/models/api_service.py
+++ b/aana/core/models/api_service.py
@@ -1,5 +1,7 @@
+from typing import Annotated
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+from pydantic.json_schema import SkipJsonSchema
 
 
 class ApiKey(BaseModel):
@@ -9,3 +11,17 @@ class ApiKey(BaseModel):
     user_id: str
     subscription_id: str
     is_subscription_active: bool
+
+
+ApiKeyType = SkipJsonSchema[Annotated[ApiKey, Field(default=None)]]
+"""
+Type with optional API key information.
+
+Can be None if API service is disabled. Otherwise, it will be an instance of `ApiKey`.
+
+Attributes:
+    api_key (str): The API key.
+    user_id (str): The user ID.
+    subscription_id (str): The subscription ID.
+    is_subscription_active (bool): Flag indicating if the subscription is active.
+"""

--- a/aana/exceptions/api_service.py
+++ b/aana/exceptions/api_service.py
@@ -1,0 +1,60 @@
+from aana.exceptions.core import BaseException
+
+
+class ApiKeyNotProvided(BaseException):
+    """Exception raised when the API key is not provided."""
+
+    def __init__(self):
+        """Initialize the exception."""
+        self.message = "API key not provided"
+        super().__init__(message=self.message)
+
+    def __reduce__(self):
+        """Used for pickling."""
+        return (self.__class__, ())
+
+
+class ApiKeyNotFound(BaseException):
+    """Exception raised when the API key is not found.
+
+    Attributes:
+        key (str): the API key that was not found
+    """
+
+    def __init__(self, key: str):
+        """Initialize the exception.
+
+        Args:
+            key (str): the API key that was not found
+        """
+        self.key = key
+        self.message = f"API key {key} not found"
+        super().__init__(key=key, message=self.message)
+
+    def __reduce__(self):
+        """Used for pickling."""
+        return (self.__class__, (self.key,))
+
+
+class InactiveSubscription(BaseException):
+    """Exception raised when the subscription is inactive (e.g. credits are not available).
+
+    Attributes:
+        key (str): the API key with inactive subscription
+    """
+
+    def __init__(self, key: str):
+        """Initialize the exception.
+
+        Args:
+            key (str): the API key with inactive subscription
+        """
+        self.key = key
+        self.message = (
+            f"API key {key} has an inactive subscription. Check your credits."
+        )
+        super().__init__(key=key, message=self.message)
+
+    def __reduce__(self):
+        """Used for pickling."""
+        return (self.__class__, (self.key,))

--- a/aana/storage/models/api_key.py
+++ b/aana/storage/models/api_key.py
@@ -1,0 +1,42 @@
+
+from sqlalchemy import Boolean
+from sqlalchemy.orm import Mapped, mapped_column
+
+from aana.storage.models.base import BaseEntity, TimeStampEntity
+
+
+class ApiKeyEntity(BaseEntity, TimeStampEntity):
+    """Table for API keys."""
+
+    __tablename__ = "api_keys"
+
+    id: Mapped[int] = mapped_column(autoincrement=True, primary_key=True)
+    api_key: Mapped[str] = mapped_column(
+        nullable=False, unique=True, comment="The API key"
+    )
+    user_id: Mapped[str] = mapped_column(
+        nullable=False, comment="ID of the user who owns this API key"
+    )
+    subscription_id: Mapped[str] = mapped_column(
+        nullable=False, comment="ID of the associated subscription"
+    )
+    is_subscription_active: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=True,
+        comment="Whether the subscription is active (credits are available)",
+    )
+
+    def __repr__(self) -> str:
+        """String representation of the API key."""
+        return (
+            f"<APIKeyEntity(id={self.id}, "
+            f"user_id={self.user_id}, "
+            f"subscription_id={self.subscription_id}, "
+            f"is_subscription_active={self.is_subscription_active}, "
+            f"updated_at={self.updated_at})>"
+        )
+
+    def to_dict(self) -> dict:
+        """Convert the object to a dictionary."""
+        return {c.name: getattr(self, c.name) for c in self.__table__.columns}

--- a/poetry.lock
+++ b/poetry.lock
@@ -698,6 +698,22 @@ files = [
 ]
 
 [[package]]
+name = "classes"
+version = "0.4.1"
+description = "Smart, pythonic, ad-hoc, typed polymorphism for Python"
+optional = true
+python-versions = ">=3.7,<4.0"
+groups = ["main"]
+markers = "(python_version >= \"3.12\" or python_version <= \"3.11\") and extra == \"api-service\""
+files = [
+    {file = "classes-0.4.1-py3-none-any.whl", hash = "sha256:934a19eb23d2fe0c0430af6eae6d81a4d4fcc53519cf737f69c3bba3994d54e9"},
+    {file = "classes-0.4.1.tar.gz", hash = "sha256:4de4fdd6c5c38607bbd8ad76703d7cc4dbe007cfa78e8ef1f62fc6ac55303e23"},
+]
+
+[package.dependencies]
+typing_extensions = ">=3.10,<5.0"
+
+[[package]]
 name = "click"
 version = "8.1.8"
 description = "Composable command line interface toolkit"
@@ -2680,6 +2696,29 @@ files = [
     {file = "kiwisolver-1.4.8-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:65ea09a5a3faadd59c2ce96dc7bf0f364986a315949dc6374f04396b0d60e09b"},
     {file = "kiwisolver-1.4.8.tar.gz", hash = "sha256:23d5f023bdc8c7e54eb65f03ca5d5bb25b601eac4d7f1a042888a1f45237987e"},
 ]
+
+[[package]]
+name = "lago-python-client"
+version = "1.19.0"
+description = "Lago Python API Client"
+optional = true
+python-versions = ">3.6"
+groups = ["main"]
+markers = "(python_version >= \"3.12\" or python_version <= \"3.11\") and extra == \"api-service\""
+files = [
+    {file = "lago_python_client-1.19.0-py3-none-any.whl", hash = "sha256:c2858f7fd999b15852119686069ccc89b69ad9e7dd2a852f669bce910f2572fb"},
+    {file = "lago_python_client-1.19.0.tar.gz", hash = "sha256:36ce4df02ff48e8f384d804d320b89c99d96a37b1a11a161559feeac3c9e84a9"},
+]
+
+[package.dependencies]
+classes = ">=0.4.1,<0.5.0"
+httpx = ">=0.24.0,<1.0.0"
+orjson = ">=3.8,<4.0"
+pydantic = ">=1.10,<3"
+typeguard = ">=3.0.2,<3.1.0"
+
+[package.extras]
+test = ["mypy (==0.971)", "pytest", "pytest_httpx"]
 
 [[package]]
 name = "lark"
@@ -8357,6 +8396,26 @@ tests = ["autopep8", "flake8", "isort", "llnl-hatchet", "numpy", "pytest", "scip
 tutorials = ["matplotlib", "pandas", "tabulate"]
 
 [[package]]
+name = "typeguard"
+version = "3.0.2"
+description = "Run-time type checker for Python"
+optional = true
+python-versions = ">=3.7.4"
+groups = ["main"]
+markers = "(python_version >= \"3.12\" or python_version <= \"3.11\") and extra == \"api-service\""
+files = [
+    {file = "typeguard-3.0.2-py3-none-any.whl", hash = "sha256:bbe993854385284ab42fd5bd3bee6f6556577ce8b50696d6cb956d704f286c8e"},
+    {file = "typeguard-3.0.2.tar.gz", hash = "sha256:fee5297fdb28f8e9efcb8142b5ee219e02375509cd77ea9d270b5af826358d5a"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.4.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+doc = ["packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
+test = ["mypy (>=0.991)", "pytest (>=7)"]
+
+[[package]]
 name = "typer"
 version = "0.15.1"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
@@ -9198,6 +9257,7 @@ type = ["pytest-mypy"]
 
 [extras]
 all = ["accelerate", "bitblas", "bitsandbytes", "hqq", "mobius-faster-whisper", "outlines", "pyannote-audio", "transformers", "vllm"]
+api-service = ["lago-python-client", "tenacity"]
 asr = ["mobius-faster-whisper", "pyannote-audio"]
 hqq = ["accelerate", "bitblas", "bitsandbytes", "hqq", "transformers"]
 transformers = ["accelerate", "bitsandbytes", "transformers"]
@@ -9206,4 +9266,4 @@ vllm = ["outlines", "vllm"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "b192b4a16f7b6553e94dcec27aa0cb7bdcd73800220a9d0cb4f34807004ece66"
+content-hash = "5304bf7fd4cc7df21c79283b02a0b6371e63c456d0c40b0f82e8f7e8e194fa4e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,11 @@ hqq = [
     "transformers>=4.47.0"
 ]
 
+api-service = [
+    "lago-python-client>=1.19.0",
+    "tenacity>=9.0.0",
+]
+
 all = [
     "accelerate>=0.34.2",
     "bitblas>=0.0.1.dev15",


### PR DESCRIPTION
Introduce middleware for API key validation and integrate LAGO API service for usage tracking.

How to use API service in your Aana Application:

1. Enable API service by setting the environment variable API_SERVICE__ENABLED=True.
2. Set API_SERVICE__LAGO_URL and API_SERVICE__LAGO_API_KEY environment variables if you want to send usage events to Lago.
3. Add the ApiKeyType parameter to the run method of the endpoint that you want to track usage for or if you need API key information (e.g., to implement multi-tenancy).
4. Send usage events using the send_usage_event method of the endpoint class.

```python
from aana.api.api_generation import Endpoint
from aana.core.models.api_service import ApiKeyType

class SearchEndpoint(Endpoint):
    async def run(self, query: str, collection: str, api_key: ApiKeyType) -> SearchOutput:
      # If API Service is disabled, api_key will be None.
      if not api_key:
         raise Exception("API key is required")

      # API key data can be used to implement multi-tenancy
      collection = f"{api_key.user_id}_{collection}" 

      # Send usage event to Lago for usage tracking
      self.send_usage_event(api_key, "search", {"query": 1})

      # Your search logic here
      return SearchOutput(results=results)
```