### PR TITLE
Enhance API Key Validation and Admin Access Control

### DIFF
--- a/aana/api/api_generation.py
+++ b/aana/api/api_generation.py
@@ -47,6 +47,7 @@ class Endpoint:
         path (str): Path of the endpoint (e.g. "/video/transcribe").
         summary (str): Description of the endpoint that will be shown in the API documentation.
         admin_required (bool): Flag indicating if the endpoint requires admin access.
+        always_defer (bool): Flag indicating if the endpoint should always defer execution to the task queue.
         event_handlers (list[EventHandler] | None): The list of event handlers to register for the endpoint.
     """
 
@@ -54,6 +55,7 @@ class Endpoint:
     path: str
     summary: str
     admin_required: bool = False
+    always_defer: bool = False
     initialized: bool = False
     event_handlers: list[EventHandler] | None = None
 
@@ -326,11 +328,15 @@ class Endpoint:
             defer: bool = Query(
                 description="Defer execution of the endpoint to the task queue.",
                 default=False,
-                include_in_schema=aana_settings.task_queue.enabled,
+                include_in_schema=aana_settings.task_queue.enabled
+                and not self.always_defer,
             ),
         ):
             if self.admin_required:
                 check_admin_permissions(request)
+
+            if self.always_defer:
+                defer = True
 
             form_data = await request.form()
 

--- a/aana/api/api_generation.py
+++ b/aana/api/api_generation.py
@@ -18,6 +18,7 @@ from aana.api.event_handlers.event_handler import EventHandler
 from aana.api.event_handlers.event_manager import EventManager
 from aana.api.exception_handler import custom_exception_handler
 from aana.api.responses import AanaJSONResponse
+from aana.api.security import check_admin_permissions
 from aana.configs.settings import settings as aana_settings
 from aana.core.models.api_service import ApiKey
 from aana.core.models.exception import ExceptionResponseModel
@@ -45,12 +46,14 @@ class Endpoint:
         name (str): Name of the endpoint.
         path (str): Path of the endpoint (e.g. "/video/transcribe").
         summary (str): Description of the endpoint that will be shown in the API documentation.
+        admin_required (bool): Flag indicating if the endpoint requires admin access.
         event_handlers (list[EventHandler] | None): The list of event handlers to register for the endpoint.
     """
 
     name: str
     path: str
     summary: str
+    admin_required: bool = False
     initialized: bool = False
     event_handlers: list[EventHandler] | None = None
 
@@ -326,6 +329,9 @@ class Endpoint:
                 include_in_schema=aana_settings.task_queue.enabled,
             ),
         ):
+            if self.admin_required:
+                check_admin_permissions(request)
+
             form_data = await request.form()
 
             # Parse files from the form data

--- a/aana/api/api_generation.py
+++ b/aana/api/api_generation.py
@@ -332,7 +332,7 @@ class Endpoint:
                 and not self.always_defer,
             ),
         ):
-            if self.admin_required:
+            if aana_settings.api_service.enabled and self.admin_required:
                 check_admin_permissions(request)
 
             if self.always_defer:

--- a/aana/api/request_handler.py
+++ b/aana/api/request_handler.py
@@ -16,6 +16,7 @@ from aana.api.app import app
 from aana.api.event_handlers.event_manager import EventManager
 from aana.api.exception_handler import custom_exception_handler
 from aana.api.responses import AanaJSONResponse
+from aana.api.security import AdminRequired
 from aana.configs.settings import settings as aana_settings
 from aana.core.models.api import DeploymentStatus, SDKStatus, SDKStatusResponse
 from aana.core.models.chat import ChatCompletion, ChatCompletionRequest, ChatDialog
@@ -274,7 +275,7 @@ class RequestHandler:
             }
 
     @app.get("/api/status", response_model=SDKStatusResponse)
-    async def status(self) -> SDKStatusResponse:
+    async def status(self, is_admin: AdminRequired) -> SDKStatusResponse:
         """The endpoint for checking the status of the application."""
         app_names = [
             self.app_name,

--- a/aana/api/request_handler.py
+++ b/aana/api/request_handler.py
@@ -202,9 +202,22 @@ class RequestHandler:
         task = task_repo.delete(task_id)
         return TaskId(task_id=str(task.id))
 
-    @app.post("/chat/completions", response_model=ChatCompletion)
+    @app.post(
+        "/chat/completions",
+        response_model=ChatCompletion,
+        include_in_schema=aana_settings.openai_endpoint_enabled,
+    )
     async def chat_completions(self, request: ChatCompletionRequest):
         """Handle chat completions requests for OpenAI compatible API."""
+        if not aana_settings.openai_endpoint_enabled:
+            return AanaJSONResponse(
+                content={
+                    "error": {
+                        "message": "The OpenAI-compatible endpoint is not enabled."
+                    }
+                },
+                status_code=404,
+            )
 
         async def _async_chat_completions(
             handle: AanaDeploymentHandle,

--- a/aana/api/security.py
+++ b/aana/api/security.py
@@ -2,6 +2,7 @@ from typing import Annotated
 
 from fastapi import Depends, Request
 
+from aana.configs.settings import settings as aana_settings
 from aana.exceptions.api_service import AdminOnlyAccess
 
 
@@ -14,10 +15,11 @@ def check_admin_permissions(request: Request):
     Raises:
         AdminOnlyAccess: If the user is not an admin
     """
-    api_key_info = request.state.api_key_info
-    is_admin = api_key_info.get("is_admin", False)
-    if not is_admin:
-        raise AdminOnlyAccess()
+    if aana_settings.api_service.enabled:
+        api_key_info = request.state.api_key_info
+        is_admin = api_key_info.get("is_admin", False)
+        if not is_admin:
+            raise AdminOnlyAccess()
 
 
 class AdminCheck:

--- a/aana/api/security.py
+++ b/aana/api/security.py
@@ -1,0 +1,33 @@
+from typing import Annotated
+
+from fastapi import Depends, Request
+
+from aana.exceptions.api_service import AdminOnlyAccess
+
+
+def check_admin_permissions(request: Request):
+    """Check if the user is an admin.
+
+    Args:
+        request (Request): The request object
+
+    Raises:
+        AdminOnlyAccess: If the user is not an admin
+    """
+    api_key_info = request.state.api_key_info
+    is_admin = api_key_info.get("is_admin", False)
+    if not is_admin:
+        raise AdminOnlyAccess()
+
+
+class AdminCheck:
+    """Dependency to check if the user is an admin."""
+
+    async def __call__(self, request: Request) -> bool:
+        """Check if the user is an admin."""
+        check_admin_permissions(request)
+        return True
+
+
+AdminRequired = Annotated[bool, Depends(AdminCheck())]
+""" Annotation to check if the user is an admin. If not, it will raise an exception. """

--- a/aana/configs/settings.py
+++ b/aana/configs/settings.py
@@ -66,6 +66,7 @@ class Settings(BaseSettings):
         audio_dir (Path): The temporary audio directory.
         model_dir (Path): The temporary model directory.
         num_workers (int): The number of web workers.
+        openai_endpoint_enabled (bool): Flag indicating if the OpenAI-compatible endpoint is enabled. Disabled by default.
         task_queue (TaskQueueSettings): The task queue settings.
         db_config (DbSettings): The database configuration.
         test (TestSettings): The test settings.
@@ -78,6 +79,8 @@ class Settings(BaseSettings):
     model_dir: Path | None = None
 
     num_workers: int = 2
+
+    openai_endpoint_enabled: bool = False
 
     task_queue: TaskQueueSettings = TaskQueueSettings()
 

--- a/aana/configs/settings.py
+++ b/aana/configs/settings.py
@@ -66,7 +66,7 @@ class Settings(BaseSettings):
         audio_dir (Path): The temporary audio directory.
         model_dir (Path): The temporary model directory.
         num_workers (int): The number of web workers.
-        openai_endpoint_enabled (bool): Flag indicating if the OpenAI-compatible endpoint is enabled. Disabled by default.
+        openai_endpoint_enabled (bool): Flag indicating if the OpenAI-compatible endpoint is enabled. Enabled by default.
         task_queue (TaskQueueSettings): The task queue settings.
         db_config (DbSettings): The database configuration.
         test (TestSettings): The test settings.
@@ -80,7 +80,7 @@ class Settings(BaseSettings):
 
     num_workers: int = 2
 
-    openai_endpoint_enabled: bool = False
+    openai_endpoint_enabled: bool = True
 
     task_queue: TaskQueueSettings = TaskQueueSettings()
 

--- a/aana/exceptions/api_service.py
+++ b/aana/exceptions/api_service.py
@@ -58,3 +58,29 @@ class InactiveSubscription(BaseException):
     def __reduce__(self):
         """Used for pickling."""
         return (self.__class__, (self.key,))
+
+
+class AdminOnlyAccess(BaseException):
+    """Exception raised when the user does not have enough permissions."""
+
+    def __init__(self):
+        """Initialize the exception."""
+        self.message = "Admin only access"
+        super().__init__(message=self.message)
+
+    def __reduce__(self):
+        """Used for pickling."""
+        return (self.__class__, ())
+
+
+class ApiKeyValidationFailed(BaseException):
+    """Exception raised when the API key validation fails."""
+
+    def __init__(self):
+        """Initialize the exception."""
+        self.message = "API key validation failed"
+        super().__init__(message=self.message)
+
+    def __reduce__(self):
+        """Used for pickling."""
+        return (self.__class__, ())

--- a/aana/sdk.py
+++ b/aana/sdk.py
@@ -15,7 +15,7 @@ from ray.serve.deployment import Application, Deployment
 from ray.serve.schema import ApplicationStatusOverview
 from rich import print as rprint
 
-from aana.api.api_generation import Endpoint
+from aana.api.api_generation import DeferOption, Endpoint
 from aana.api.event_handlers.event_handler import EventHandler
 from aana.api.request_handler import RequestHandler
 from aana.configs.settings import settings as aana_settings
@@ -267,7 +267,7 @@ class AanaSDK:
         summary: str,
         endpoint_cls: type[Endpoint],
         admin_required: bool = False,
-        always_defer: bool = False,
+        defer_option: DeferOption = DeferOption.OPTIONAL,
         event_handlers: list[EventHandler] | None = None,
     ):
         """Register an endpoint.
@@ -278,7 +278,7 @@ class AanaSDK:
             summary (str): The summary of the endpoint.
             endpoint_cls (Type[Endpoint]): The class of the endpoint.
             admin_required (bool, optional): If True, the endpoint requires admin access. Defaults to False.
-            always_defer (bool, optional): If True, the endpoint will always defer execution to the task queue. Defaults to False.
+            defer_option (DeferOption): Defer option for the endpoint (always, never, optional).
             event_handlers (list[EventHandler], optional): The event handlers to register for the endpoint.
         """
         endpoint = endpoint_cls(
@@ -286,7 +286,7 @@ class AanaSDK:
             path=path,
             summary=summary,
             admin_required=admin_required,
-            always_defer=always_defer,
+            defer_option=defer_option,
             event_handlers=event_handlers,
         )
         self.endpoints[name] = endpoint

--- a/aana/sdk.py
+++ b/aana/sdk.py
@@ -267,6 +267,7 @@ class AanaSDK:
         summary: str,
         endpoint_cls: type[Endpoint],
         admin_required: bool = False,
+        always_defer: bool = False,
         event_handlers: list[EventHandler] | None = None,
     ):
         """Register an endpoint.
@@ -277,6 +278,7 @@ class AanaSDK:
             summary (str): The summary of the endpoint.
             endpoint_cls (Type[Endpoint]): The class of the endpoint.
             admin_required (bool, optional): If True, the endpoint requires admin access. Defaults to False.
+            always_defer (bool, optional): If True, the endpoint will always defer execution to the task queue. Defaults to False.
             event_handlers (list[EventHandler], optional): The event handlers to register for the endpoint.
         """
         endpoint = endpoint_cls(
@@ -284,6 +286,7 @@ class AanaSDK:
             path=path,
             summary=summary,
             admin_required=admin_required,
+            always_defer=always_defer,
             event_handlers=event_handlers,
         )
         self.endpoints[name] = endpoint

--- a/aana/sdk.py
+++ b/aana/sdk.py
@@ -266,6 +266,7 @@ class AanaSDK:
         path: str,
         summary: str,
         endpoint_cls: type[Endpoint],
+        admin_required: bool = False,
         event_handlers: list[EventHandler] | None = None,
     ):
         """Register an endpoint.
@@ -275,12 +276,14 @@ class AanaSDK:
             path (str): The path of the endpoint.
             summary (str): The summary of the endpoint.
             endpoint_cls (Type[Endpoint]): The class of the endpoint.
+            admin_required (bool, optional): If True, the endpoint requires admin access. Defaults to False.
             event_handlers (list[EventHandler], optional): The event handlers to register for the endpoint.
         """
         endpoint = endpoint_cls(
             name=name,
             path=path,
             summary=summary,
+            admin_required=admin_required,
             event_handlers=event_handlers,
         )
         self.endpoints[name] = endpoint

--- a/aana/storage/models/api_key.py
+++ b/aana/storage/models/api_key.py
@@ -20,6 +20,9 @@ class ApiKeyEntity(ApiServiceBase):
     user_id: Mapped[str] = mapped_column(
         nullable=False, comment="ID of the user who owns this API key"
     )
+    is_admin: Mapped[bool] = mapped_column(
+        nullable=False, default=False, comment="Whether the user is an admin"
+    )
     subscription_id: Mapped[str] = mapped_column(
         nullable=False, comment="ID of the associated subscription"
     )
@@ -34,7 +37,9 @@ class ApiKeyEntity(ApiServiceBase):
         """String representation of the API key."""
         return (
             f"<APIKeyEntity(id={self.id}, "
+            f"api_key={self.api_key}, "
             f"user_id={self.user_id}, "
+            f"is_admin={self.is_admin}, "
             f"subscription_id={self.subscription_id}, "
             f"is_subscription_active={self.is_subscription_active})>"
         )

--- a/docs/pages/openai_api.md
+++ b/docs/pages/openai_api.md
@@ -4,6 +4,9 @@ Aana SDK provides an OpenAI-compatible Chat Completions API that allows you to i
 
 Chat Completions API is available at the `/chat/completions` endpoint.
 
+!!! Tip
+    The endpoint is enabled by default but can be disabled by setting the environment variable: `OPENAI_ENDPOINT_ENABLED=False`.
+
 It is compatible with the OpenAI client libraries and can be used as a drop-in replacement for OpenAI API.
 
 ```python


### PR DESCRIPTION
- Improved API key validation with better error handling
- Introduced admin access requirements for certain endpoints
- Introduced two new options for user-defined endpoints:
    - `admin_required`: Flag indicating if the endpoint requires admin access.
    - `always_defer`: Flag indicating if the endpoint should always defer execution to the task queue.
- Added configuration options for enabling or disabling the OpenAI-compatible chat endpoint.