### PR TITLE
Fix Validation Error Handler

### DIFF
--- a/aana/api/exception_handler.py
+++ b/aana/api/exception_handler.py
@@ -27,6 +27,10 @@ async def validation_exception_handler(
         data = exc.errors(include_context=False)
     elif isinstance(exc, RequestValidationError):
         data = exc.errors()
+        # Remove ctx from the error messages
+        for error in data:
+            if "ctx" in error:
+                error.pop("ctx")
     return AanaJSONResponse(
         status_code=422,
         content=ExceptionResponseModel(

--- a/aana/core/models/media.py
+++ b/aana/core/models/media.py
@@ -2,43 +2,15 @@ import hashlib
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated
 
-from pydantic import Field, ValidationInfo, ValidatorFunctionWrapHandler
-from pydantic.functional_validators import WrapValidator
+from pydantic import Field
 
 from aana.utils.download import download_file
 
-
-def verify_media_id_must_not_be_empty(
-    v: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo
-) -> str:
-    """Validates that the media_id is not an empty string."""
-    assert v != "", "media_id cannot be an empty string"  # noqa: S101
-    return v
-
-
-def verify_media_id_length(
-    v: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo
-) -> str:
-    """Validates that the media_id is maximum 36 characters long."""
-    assert len(v) <= 36, "media_id must be at most 36 characters long"  # noqa: S101
-    return v
-
-
-def verify_media_id(
-    v: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo
-) -> str:
-    """Validates the media_id."""
-    v = verify_media_id_must_not_be_empty(v, handler, info)
-    v = verify_media_id_length(v, handler, info)
-    return v
-
-
 MediaId = Annotated[
     str,
-    Field(description="The media ID.", max_length=36),
-    WrapValidator(verify_media_id),
+    Field(description="The media ID.", max_length=36, min_length=1),
 ]
 """
 The media ID (str, max length 36 characters).

--- a/aana/core/models/media.py
+++ b/aana/core/models/media.py
@@ -10,7 +10,12 @@ from aana.utils.download import download_file
 
 MediaId = Annotated[
     str,
-    Field(description="The media ID.", max_length=36, min_length=1),
+    Field(
+        description="The media ID.",
+        max_length=36,
+        min_length=1,
+        pattern=r"^[A-Za-z0-9_-]+$",
+    ),
 ]
 """
 The media ID (str, max length 36 characters).

--- a/aana/tests/units/test_media_id.py
+++ b/aana/tests/units/test_media_id.py
@@ -6,12 +6,14 @@ from pydantic import BaseModel, ValidationError
 from aana.core.models.media import MediaId
 
 
+class TestModel(BaseModel):
+    """Test model for media id."""
+
+    media_id: MediaId
+
+
 def test_media_id_creation():
     """Test that a media id can be created."""
-
-    class TestModel(BaseModel):
-        media_id: MediaId
-
     media_id = TestModel(media_id="foo").media_id
     assert media_id == "foo"
 
@@ -26,3 +28,24 @@ def test_media_id_creation():
     # MediaId is a string with a maximum length of 36
     with pytest.raises(ValidationError):
         TestModel(media_id="a" * 37).media_id  # noqa: B018
+
+
+def test_valid_media_ids():
+    """Test that valid media ids are accepted."""
+    valid_ids = ["abc123", "abc-123", "abc_123", "A1B2_C3", "123456", "a_b-c"]
+    for media_id in valid_ids:
+        model = TestModel(media_id=media_id)
+        assert model.media_id == media_id
+
+
+def test_invalid_media_ids():
+    """Test that invalid media ids are rejected."""
+    invalid_ids = [
+        "abc 123",  # contains a space
+        "abc@123",  # contains an invalid character (@)
+        "abc#123",  # contains an invalid character (#)
+        "abc.123",  # contains an invalid character (.)
+    ]
+    for media_id in invalid_ids:
+        with pytest.raises(ValidationError):
+            TestModel(media_id=media_id)


### PR DESCRIPTION
Remove unnecessary context from validation error messages and streamline the media ID validation logic for clarity and efficiency.