### PR TITLE
Add X-Accel-Buffering header to StreamingResponse

### DIFF
--- a/aana/api/api_generation.py
+++ b/aana/api/api_generation.py
@@ -346,7 +346,11 @@ class Endpoint:
                         yield custom_exception_handler(None, e).body
 
                 return StreamingResponse(
-                    generator_wrapper(), media_type="application/x-ndjson"
+                    generator_wrapper(),
+                    media_type="application/x-ndjson",
+                    headers={
+                        "X-Accel-Buffering": "no",
+                    },
                 )
             else:
                 try:


### PR DESCRIPTION
Add the `X-Accel-Buffering` header to the `StreamingResponse` in the Endpoint class to enable realtime streaming when deployed with nginx.