### PR TITLE
Replace references to ndjson with concatenated JSON

### DIFF
--- a/aana/api/api_generation.py
+++ b/aana/api/api_generation.py
@@ -17,7 +17,7 @@ from starlette.datastructures import UploadFile as StarletteUploadFile
 from aana.api.event_handlers.event_handler import EventHandler
 from aana.api.event_handlers.event_manager import EventManager
 from aana.api.exception_handler import custom_exception_handler
-from aana.api.responses import AanaJSONResponse, AanaNDJSONResponse
+from aana.api.responses import AanaConcatenatedJSONResponse, AanaJSONResponse
 from aana.api.security import require_active_subscription, require_admin_access
 from aana.configs.settings import settings as aana_settings
 from aana.core.models.api_service import ApiKey
@@ -139,7 +139,7 @@ class Endpoint:
             ResponseModel = TaskResponse
 
         if self.is_streaming_response():
-            response_class = AanaNDJSONResponse
+            response_class = AanaConcatenatedJSONResponse
         else:
             response_class = AanaJSONResponse
 
@@ -341,13 +341,13 @@ class Endpoint:
                     """Serializes the output of the generator using ORJSONResponseCustom."""
                     try:
                         async for output in self.run(**data_dict):
-                            yield AanaNDJSONResponse(content=output).body
+                            yield AanaConcatenatedJSONResponse(content=output).body
                     except Exception as e:
                         yield custom_exception_handler(None, e).body
 
                 return StreamingResponse(
                     generator_wrapper(),
-                    media_type="application/x-ndjson",
+                    media_type="application/json-seq",
                     headers={
                         "X-Accel-Buffering": "no",
                     },

--- a/aana/api/responses.py
+++ b/aana/api/responses.py
@@ -31,7 +31,7 @@ class AanaJSONResponse(JSONResponse):
         return jsonify(content, option=self.option, as_bytes=True)
 
 
-class AanaNDJSONResponse(AanaJSONResponse):
-    """Response class that uses orjson to serialize data to newline-delimited JSON (NDJSON)."""
+class AanaConcatenatedJSONResponse(AanaJSONResponse):
+    """Response class that uses orjson to serialize data to Concatenated JSON format."""
 
-    media_type = "application/x-ndjson"
+    media_type = "application/json-seq"

--- a/aana/routers/openai.py
+++ b/aana/routers/openai.py
@@ -87,7 +87,10 @@ async def chat_completions(request: ChatCompletionRequest):
     if request.stream:
         return StreamingResponse(
             _async_chat_completions(handle, dialog, sampling_params),
-            media_type="application/x-ndjson",
+            media_type="application/json-seq",
+            headers={
+                "X-Accel-Buffering": "no",
+            },
         )
     else:
         response = await handle.chat(dialog=dialog, sampling_params=sampling_params)

--- a/aana/utils/openapi.py
+++ b/aana/utils/openapi.py
@@ -211,7 +211,7 @@ def add_code_samples_to_endpoints(openapi_spec: dict) -> dict:
 
             response = operation.get("responses", {}).get("200", {})
             response_content_type = response.get("content", {}).keys()
-            is_streaming = "application/x-ndjson" in response_content_type
+            is_streaming = "application/json-seq" in response_content_type
 
             # Extract the JSON schema for the form data.
             schema = content["application/x-www-form-urlencoded"].get("schema", {})

--- a/aana/utils/openapi_code_templates/python_form_streaming.j2
+++ b/aana/utils/openapi_code_templates/python_form_streaming.j2
@@ -1,4 +1,5 @@
 import json, requests
+import ijson # pip install ijson
 
 payload = {{ body }}
 
@@ -13,6 +14,5 @@ response = requests.post("{{ base_url }}{{ path }}",
     stream=True
 )
 
-for chunk in response.iter_content(chunk_size=None):
-    json_data = json.loads(chunk)
-    print(json_data)
+for obj in ijson.items(response.raw, '', multiple_values=True, buf_size=32):
+    print(obj)


### PR DESCRIPTION
- Replace references to ndjson with concatenated JSON (application/json-seq) as it is the correct response type.
- Update python snippets for the streaming endpoints in the docs.