### PR TITLE
Introduce GPU Manager

### DIFF
--- a/aana/configs/settings.py
+++ b/aana/configs/settings.py
@@ -43,6 +43,16 @@ class TaskQueueSettings(BaseModel):
     maximum_active_tasks_per_user: int = 25
 
 
+class GpuManagerSettings(BaseModel):
+    """A pydantic model for GPU manager settings.
+
+    Attributes:
+        enabled (bool): Flag indicating if the GPU manager is enabled.
+    """
+
+    enabled: bool = False
+
+
 class ApiServiceSettings(BaseModel):
     """A pydantic model for API service settings.
 
@@ -135,6 +145,8 @@ class Settings(BaseSettings):
     webhook: WebhookSettings = WebhookSettings()
 
     cors: CorsSettings = CorsSettings()
+
+    gpu_manager: GpuManagerSettings = GpuManagerSettings()
 
     @model_validator(mode="after")
     def setup_resource_directories(self):

--- a/aana/deployments/base_deployment.py
+++ b/aana/deployments/base_deployment.py
@@ -1,7 +1,13 @@
 import inspect
+import os
 from functools import wraps
 from typing import Any
 
+import ray
+from ray import serve
+
+from aana.configs.settings import settings as aana_settings
+from aana.deployments.aana_deployment_handle import AanaDeploymentHandle
 from aana.exceptions.runtime import InferenceException
 
 
@@ -55,12 +61,39 @@ class BaseDeployment:
         self.raised_exceptions = []
         self.restart_exceptions = [InferenceException]
 
+    async def request_gpu_from_manager(self):
+        """Request GPU resources for the deployment from the GPU manager."""
+        num_gpus = ray.get_runtime_context().get_assigned_resources().get("GPU", 0)
+        if num_gpus == 0:
+            print("No GPUs assigned to this replica.")
+            return
+
+        replica_context = serve.get_replica_context()
+        self._replica_id = replica_context.replica_id.unique_id
+        self._deployment_name = replica_context.replica_id.deployment_id.app_name
+        print("Replica ID:", self._replica_id)
+        print("Deployment Name:", self._deployment_name)
+        print("Original CUDA_VISIBLE_DEVICES:", os.environ["CUDA_VISIBLE_DEVICES"])
+
+        gpu_manager_handle = await AanaDeploymentHandle.create("gpu_manager")
+        gpu_ids = await gpu_manager_handle.request_gpu(
+            deployment=self._deployment_name,
+            replica_id=self._replica_id,
+            num_gpus=num_gpus,
+        )
+        print("Assigned GPUs:", gpu_ids)
+        os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, gpu_ids))
+
     async def reconfigure(self, config: dict[str, Any]):
         """Reconfigure the deployment.
 
         The method is called when the deployment is updated.
         """
         self.config = config
+
+        if aana_settings.gpu_manager.enabled:
+            await self.request_gpu_from_manager()
+
         await self.apply_config(config)
         self._configured = True
 
@@ -97,7 +130,9 @@ class BaseDeployment:
         Args:
             config (dict): the configuration
         """
-        raise NotImplementedError
+        raise NotImplementedError(
+            "apply_config method must be implemented in the deployment class."
+        )
 
     async def get_methods(self) -> dict:
         """Returns the methods of the deployment.

--- a/aana/deployments/gpu_manager.py
+++ b/aana/deployments/gpu_manager.py
@@ -1,0 +1,138 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+from ray import serve
+from ray.serve.api import _get_global_client
+
+from aana.deployments.base_deployment import BaseDeployment
+
+
+class GpuManagerConfig(BaseModel):
+    """Configuration for the GPU manager deployment."""
+
+    # Define any configuration fields here.
+    available_gpus: list[int] = Field(
+        default_factory=list,
+        description="List of available GPUs for allocation.",
+    )
+
+
+@serve.deployment
+class GpuManagerDeployment(BaseDeployment):
+    """GPU manager deployment for managing GPU allocations."""
+
+    async def apply_config(self, config: dict[str, Any]):
+        """Apply the configuration settings to the deployment."""
+        self.allocations = {}
+        config_obj = GpuManagerConfig(**config)
+        self.available_gpus = config_obj.available_gpus
+
+    def _get_available_gpus(self) -> list[int]:
+        """Get the list of available GPUs."""
+        return self.available_gpus
+
+    def _cleanup_inactive_replicas(self, active_replica_ids: set):
+        """Remove allocations for replicas that are no longer active (e.g. STOPPING or INACTIVE)."""
+        for deployment in self.allocations:
+            for rep in list(self.allocations[deployment].keys()):
+                if rep not in active_replica_ids:
+                    print(f"Cleaning up replica {rep} for deployment {deployment}")
+                    del self.allocations[deployment][rep]
+
+    def _compute_gpu_load(self) -> dict:
+        """Computes the total fraction allocated on each GPU for this deployment.
+
+        Returns:
+            dict: A dictionary mapping GPU IDs to their current load (fraction of allocated capacity).
+        """
+        load = {gpu: 0.0 for gpu in self.available_gpus}
+        for deployment in self.allocations:
+            for replica_alloc in self.allocations[deployment].values():
+                for gpu, fraction in replica_alloc.items():
+                    load[gpu] += fraction
+        return load
+
+    def _get_active_replica_ids(self) -> set:
+        """Get the IDs of active replicas."""
+        client = _get_global_client(raise_if_no_controller_running=False)
+        if client is None:
+            raise RuntimeError(  # noqa: TRY003
+                "Serve has not started yet. Cannot get active replica IDs."
+            )
+        status = client.get_serve_details()
+
+        active_replica_ids = set()
+        for app in status["applications"].values():
+            for deployment in app["deployments"]:
+                for replica in app["deployments"][deployment]["replicas"]:
+                    state = replica["state"]
+                    if state not in ["STOPPING", "INACTIVE"]:
+                        active_replica_ids.add(replica["replica_id"])
+                    print(f"Replica ID: {replica['replica_id']}, State: {state}")
+        return active_replica_ids
+
+    async def request_gpu(
+        self, deployment: str, replica_id: str, num_gpus: float
+    ) -> list[int]:
+        """Allocate GPUs for a specific deployment and replica.
+
+        Returns:
+            list[int]: A list of GPU IDs that have been allocated.
+        """
+        print(
+            f"Requesting {num_gpus} GPUs for deployment {deployment} with replica ID {replica_id}"
+        )
+        if num_gpus > 1:
+            raise NotImplementedError(
+                "Multi-GPU allocation is not yet supported. Please request only one GPU or less."
+            )
+
+        # Identify active replicas for this deployment.
+        active_replica_ids = self._get_active_replica_ids()
+
+        # Clean up any allocations for replicas that are no longer active.
+        self._cleanup_inactive_replicas(active_replica_ids)
+
+        # Ensure allocation state exists for this deployment and replica.
+        if deployment not in self.allocations:
+            self.allocations[deployment] = {}
+        if replica_id not in self.allocations[deployment]:
+            self.allocations[deployment][replica_id] = {}
+
+        # Get list of GPUs and compute current load.
+        available_gpus = self._get_available_gpus()
+        print(f"Available GPUs for deployment '{deployment}': {available_gpus}")
+        gpu_load = self._compute_gpu_load()
+        print(f"Current GPU load: {gpu_load}")
+
+        # Find GPUs already used by other replicas in this deployment.
+        used_gpus = set()
+        for rep, alloc in self.allocations[deployment].items():
+            # Skip the current replica's state.
+            if rep == replica_id:
+                continue
+            used_gpus.update(alloc.keys())
+        print(f"Used GPUs for other replicas in deployment '{deployment}': {used_gpus}")
+
+        allocated_gpus = []
+        sorted_gpus = sorted(
+            available_gpus,
+            key=lambda gpu: (gpu in used_gpus, -(1.0 - gpu_load[gpu])),
+        )
+        for gpu in sorted_gpus:
+            free_capacity = 1.0 - gpu_load[gpu]
+            if num_gpus > free_capacity:
+                continue  # Skip GPU if not enough capacity.
+            print(
+                f"Allocating {num_gpus:.2f} on GPU {gpu} for replica {replica_id} (free capacity {free_capacity:.2f})"
+            )
+            self.allocations[deployment][replica_id][gpu] = num_gpus
+            allocated_gpus.append(gpu)
+            break
+
+        if allocated_gpus == []:
+            raise Exception("Insufficient GPU capacity to fulfill the request")
+
+        print(f"Allocated GPUs for replica {replica_id}: {allocated_gpus}")
+        print(self.allocations)
+        return allocated_gpus

--- a/aana/deployments/haystack_component_deployment.py
+++ b/aana/deployments/haystack_component_deployment.py
@@ -1,54 +1,10 @@
 from typing import Any
 
-from haystack import component
 from pydantic import BaseModel
 from ray import serve
 
-from aana.deployments.aana_deployment_handle import AanaDeploymentHandle
 from aana.deployments.base_deployment import BaseDeployment, exception_handler
-from aana.utils.asyncio import run_async
 from aana.utils.core import import_from_path
-
-
-@component
-class RemoteHaystackComponent:
-    """A component that connects to a remote Haystack component created by HaystackComponentDeployment.
-
-    Attributes:
-        deployment_name (str): The name of the deployment to use.
-    """
-
-    def __init__(
-        self,
-        deployment_name: str,
-    ):
-        """Initialize the component.
-
-        Args:
-            deployment_name (str): The name of the deployment to use.
-        """
-        self.deployment_name = deployment_name
-
-    def warm_up(self):
-        """Warm up the component.
-
-        This will properly initialize the component by creating a handle to the deployment
-        and setting the input and output types.
-        """
-        if hasattr(self, "handle"):
-            return
-        self.handle = run_async(AanaDeploymentHandle.create(self.deployment_name))
-        sockets = run_async(self.handle.get_sockets())
-        component.set_input_types(
-            self, **{socket.name: socket.type for socket in sockets["input"].values()}
-        )
-        component.set_output_types(
-            self, **{socket.name: socket.type for socket in sockets["output"].values()}
-        )
-
-    def run(self, **data):
-        """Run the component on the input data."""
-        return run_async(self.handle.run(**data))
 
 
 class HaystackComponentDeploymentConfig(BaseModel):

--- a/aana/integrations/haystack/remote_haystack_component.py
+++ b/aana/integrations/haystack/remote_haystack_component.py
@@ -1,0 +1,46 @@
+
+from haystack import component
+
+from aana.deployments.aana_deployment_handle import AanaDeploymentHandle
+from aana.utils.asyncio import run_async
+
+
+@component
+class RemoteHaystackComponent:
+    """A component that connects to a remote Haystack component created by HaystackComponentDeployment.
+
+    Attributes:
+        deployment_name (str): The name of the deployment to use.
+    """
+
+    def __init__(
+        self,
+        deployment_name: str,
+    ):
+        """Initialize the component.
+
+        Args:
+            deployment_name (str): The name of the deployment to use.
+        """
+        self.deployment_name = deployment_name
+
+    def warm_up(self):
+        """Warm up the component.
+
+        This will properly initialize the component by creating a handle to the deployment
+        and setting the input and output types.
+        """
+        if hasattr(self, "handle"):
+            return
+        self.handle = run_async(AanaDeploymentHandle.create(self.deployment_name))
+        sockets = run_async(self.handle.get_sockets())
+        component.set_input_types(
+            self, **{socket.name: socket.type for socket in sockets["input"].values()}
+        )
+        component.set_output_types(
+            self, **{socket.name: socket.type for socket in sockets["output"].values()}
+        )
+
+    def run(self, **data):
+        """Run the component on the input data."""
+        return run_async(self.handle.run(**data))

--- a/aana/tests/integration/test_haystack_remote_component.py
+++ b/aana/tests/integration/test_haystack_remote_component.py
@@ -12,8 +12,8 @@ from aana.api.api_generation import Endpoint
 from aana.deployments.haystack_component_deployment import (
     HaystackComponentDeployment,
     HaystackComponentDeploymentConfig,
-    RemoteHaystackComponent,
 )
+from aana.integrations.haystack.remote_haystack_component import RemoteHaystackComponent
 
 
 class HaystackTestEndpointOutput(TypedDict):

--- a/notebooks/haystack_integration.ipynb
+++ b/notebooks/haystack_integration.ipynb
@@ -144,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -160,7 +160,7 @@
     "from haystack.components.retrievers.in_memory import InMemoryEmbeddingRetriever\n",
     "from haystack.document_stores.in_memory import InMemoryDocumentStore\n",
     "\n",
-    "from aana.deployments.haystack_component_deployment import RemoteHaystackComponent\n",
+    "from aana.integrations.haystack.remote_haystack_component import RemoteHaystackComponent\n",
     "\n",
     "document_store = InMemoryDocumentStore(embedding_similarity_function=\"cosine\")\n",
     "\n",

--- a/notebooks/rag.ipynb
+++ b/notebooks/rag.ipynb
@@ -324,7 +324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -353,7 +353,7 @@
     "from haystack_integrations.components.retrievers.qdrant import QdrantEmbeddingRetriever\n",
     "from haystack_integrations.document_stores.qdrant import QdrantDocumentStore\n",
     "\n",
-    "from aana.deployments.haystack_component_deployment import RemoteHaystackComponent\n",
+    "from aana.integrations.haystack.remote_haystack_component import RemoteHaystackComponent\n",
     "\n",
     "cleaner = DocumentCleaner()\n",
     "splitter = DocumentSplitter(split_by=\"sentence\", split_length=1)\n",


### PR DESCRIPTION
- Introduce an experimental GPU manager enhancing GPU resource allocation.
- Move RemoteHaystackComponent to a separate file.
- Update import paths in tests and notebooks to align with the new structure.

The GPU manager is an experimental feature designed to enhance the GPU allocation for multi GPU instances with GPU sharing.

Currently, Ray supports GPU sharing (partial GPU allocation) but the replicas of the same deployment are often allocated to the same GPU. This can lead to inefficient resource utilization where some GPUs are fully utilized while others are idle.

From my research, there is no way to enforce that replicas of the same deployment are allocated to different GPUs (if possible). I've tried some workarounds using Ray's placement groups, but they require monkey patching the Ray internals and have issues with Ray's autoscaler.

The GPU manager is designed to address this issue by introducing a centralized GPU allocation manager that tracks the GPU usage of each replica and ensures that replicas of the same deployment are allocated to different GPUs if possible. 

This is done by sending a request to the GPU manager when a replica is configured. The GPU manager then checks the current GPU usage and allocates a GPU to the replica accordingly. 

The feature is still experimental and may not work in all cases. Current limitations include:
- Only supports single node deployments.
- Only supports deployments that require <= 1 GPU.
- Might not work with certain deployments (test the deployment before using it in production).
