### PR TITLE
Add CORS Handling to Exception Handlers

### DIFF
--- a/aana/api/app.py
+++ b/aana/api/app.py
@@ -19,11 +19,6 @@ from aana.storage.session import get_session
 
 app = FastAPI()
 
-app.add_exception_handler(ValidationError, validation_exception_handler)
-app.add_exception_handler(RequestValidationError, validation_exception_handler)
-app.add_exception_handler(Exception, aana_exception_handler)
-
-
 app.add_middleware(
     CORSMiddleware,
     allow_origins=aana_settings.cors.allow_origins,
@@ -32,6 +27,10 @@ app.add_middleware(
     allow_methods=aana_settings.cors.allow_methods,
     allow_headers=aana_settings.cors.allow_headers,
 )
+
+app.add_exception_handler(ValidationError, validation_exception_handler)
+app.add_exception_handler(RequestValidationError, validation_exception_handler)
+app.add_exception_handler(Exception, aana_exception_handler)
 
 
 @app.middleware("http")

--- a/aana/api/exception_handler.py
+++ b/aana/api/exception_handler.py
@@ -30,13 +30,11 @@ def get_app_middleware(
         if middleware.cls == middleware_class:
             middleware_index = index
             break
+    if middleware_index is None:
+        return None
 
     middleware = app.user_middleware[middleware_index]
-    return (
-        None
-        if middleware_index is None
-        else middleware.cls(app, *middleware.args, **middleware.kwargs)
-    )
+    return middleware.cls(app, *middleware.args, **middleware.kwargs)
 
 
 def add_cors_headers(request: Request, response: AanaJSONResponse):


### PR DESCRIPTION
Implement CORS handling in custom exception handlers to ensure proper CORS headers are included for error.


## Context
CORS middleware and custom exception handlers don't work well together. CORS middleware is skipped and headers are not added.

The official solution is to wrap the entire application with CORSMiddleware. But in our case it's not possible because we use Ray and it expects FastAPI app, not CORSMiddleware.

See https://github.com/fastapi/fastapi/discussions/8027 for more info.