### PR TITLE
Add API Key Expiration Check

### DIFF
--- a/aana/api/app.py
+++ b/aana/api/app.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
@@ -10,6 +12,7 @@ from aana.api.exception_handler import (
 )
 from aana.configs.settings import settings as aana_settings
 from aana.exceptions.api_service import (
+    ApiKeyExpired,
     ApiKeyNotFound,
     ApiKeyNotProvided,
     ApiKeyValidationFailed,
@@ -57,6 +60,9 @@ async def api_key_check(request: Request, call_next):
 
             if not api_key_info:
                 raise ApiKeyNotFound(key=api_key)
+
+            if api_key_info.expired_at < datetime.now(timezone.utc):
+                raise ApiKeyExpired(key=api_key)
 
             request.state.api_key_info = api_key_info.to_model()
 

--- a/aana/exceptions/api_service.py
+++ b/aana/exceptions/api_service.py
@@ -84,3 +84,21 @@ class ApiKeyValidationFailed(BaseException):
     def __reduce__(self):
         """Used for pickling."""
         return (self.__class__, ())
+
+
+class ApiKeyExpired(BaseException):
+    """Exception raised when the API key is expired."""
+
+    def __init__(self, key: str):
+        """Initialize the exception.
+
+        Args:
+            key (str): the expired API key
+        """
+        self.key = key
+        self.message = f"API key {key} is expired."
+        super().__init__(key=key, message=self.message)
+
+    def __reduce__(self):
+        """Used for pickling."""
+        return (self.__class__, (self.key,))


### PR DESCRIPTION
Introduce an exception for expired API keys and update the API key validation logic to raise this exception when an API key is expired. Enhance test cases to cover scenarios involving expired API keys.