### PR TITLE
Remove Stacktrace for non-Admin Users

### DIFF
--- a/aana/api/api_generation.py
+++ b/aana/api/api_generation.py
@@ -345,7 +345,7 @@ class Endpoint:
                         async for output in self.run(**data_dict):
                             yield AanaConcatenatedJSONResponse(content=output).body
                     except Exception as e:
-                        yield custom_exception_handler(None, e).body
+                        yield custom_exception_handler(request, e).body
 
                 return StreamingResponse(
                     generator_wrapper(),
@@ -358,7 +358,7 @@ class Endpoint:
                 try:
                     output = await self.run(**data_dict)
                 except Exception as e:
-                    return custom_exception_handler(None, e)
+                    return custom_exception_handler(request, e)
                 return AanaJSONResponse(content=output)
 
         async def route_func(

--- a/aana/core/models/task.py
+++ b/aana/core/models/task.py
@@ -52,7 +52,7 @@ class TaskInfo(BaseModel):
     )
 
     @classmethod
-    def from_entity(cls, task: TaskEntity) -> "TaskInfo":
+    def from_entity(cls, task: TaskEntity, is_admin: bool = False) -> "TaskInfo":
         """Create a TaskInfo from a TaskEntity."""
         # Prepare data (remove ApiKey, None values, etc.)
         task_data = {}
@@ -60,6 +60,10 @@ class TaskInfo(BaseModel):
             if value is None or isinstance(value, ApiKey):
                 continue
             task_data[key] = value
+
+        # Remove stacktrace from result if not admin
+        if not is_admin and "stacktrace" in task.result:
+            task.result.pop("stacktrace", None)
 
         return TaskInfo(
             id=str(task.id),


### PR DESCRIPTION
Improve exception handling by removing stack traces for non-admin users and logging stack traces for debugging purposes. Update task information retrieval to conditionally include stack traces based on user permissions.

This is done to prevent leaking implementation details while keeping stacktrace available for admin users for easy debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Stack traces in error responses and task results are now only visible to admin users, enhancing privacy for non-admin users.
- **Bug Fixes**
	- Improved error handling by ensuring request context is consistently passed to exception handlers.
- **Other Improvements**
	- Exceptions are now logged with full stack traces for better debugging by administrators.
	- Added admin-specific tests to verify error handling and stack trace visibility in API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->