### PR TITLE
Add Retry for ActorDiedError in AanaDeploymentHandle

### DIFF
--- a/aana/core/models/task.py
+++ b/aana/core/models/task.py
@@ -62,7 +62,7 @@ class TaskInfo(BaseModel):
             task_data[key] = value
 
         # Remove stacktrace from result if not admin
-        if not is_admin and "stacktrace" in task.result:
+        if not is_admin and task.result and "stacktrace" in task.result:
             task.result.pop("stacktrace", None)
 
         return TaskInfo(

--- a/aana/deployments/aana_deployment_handle.py
+++ b/aana/deployments/aana_deployment_handle.py
@@ -48,6 +48,16 @@ class AanaDeploymentHandle:
         self.retry_delay = retry_delay
         self.retry_max_delay = retry_max_delay
 
+    def _is_exception_retryable(self, e: Exception) -> bool:
+        """Check if the exception is retryable based on the configuration."""
+        if self.retry_exceptions is True:
+            return True
+        if isinstance(self.retry_exceptions, list):
+            return isinstance(e, tuple(self.retry_exceptions)) or isinstance(
+                getattr(e, "cause", None), tuple(self.retry_exceptions)
+            )
+        return False
+
     def __create_async_method(self, name: str):  # noqa: C901
         """Create an method to interact with the deployment.
 
@@ -70,16 +80,7 @@ class AanaDeploymentHandle:
                             yield item
                         break
                     except Exception as e:
-                        is_retryable = self.retry_exceptions is True or (
-                            isinstance(self.retry_exceptions, list)
-                            and (
-                                isinstance(
-                                    getattr(e, "cause", None),
-                                    tuple(self.retry_exceptions),
-                                )
-                                or isinstance(e, tuple(self.retry_exceptions))
-                            )
-                        )
+                        is_retryable = self._is_exception_retryable(e)
                         logger.exception(
                             f"Error in method {name} on attempt {retries + 1}: {e.__class__}"
                         )
@@ -102,16 +103,7 @@ class AanaDeploymentHandle:
                             *args, **kwargs
                         )
                     except Exception as e:  # noqa: PERF203
-                        is_retryable = self.retry_exceptions is True or (
-                            isinstance(self.retry_exceptions, list)
-                            and (
-                                isinstance(
-                                    getattr(e, "cause", None),
-                                    tuple(self.retry_exceptions),
-                                )
-                                or isinstance(e, tuple(self.retry_exceptions))
-                            )
-                        )
+                        is_retryable = self._is_exception_retryable(e)
                         logger.exception(
                             f"Error in method {name} on attempt {retries + 1}: {e.__class__}"
                         )
@@ -159,7 +151,7 @@ class AanaDeploymentHandle:
             retry_exceptions = (
                 retry_exceptions if isinstance(retry_exceptions, list) else []
             )
-            retry_exceptions.append(ray.exceptions.ActorDiedError)
+            retry_exceptions = [*retry_exceptions, ray.exceptions.ActorDiedError]
 
         handle = cls(
             deployment_name=deployment_name,

--- a/aana/deployments/aana_deployment_handle.py
+++ b/aana/deployments/aana_deployment_handle.py
@@ -1,7 +1,12 @@
+import logging
+
+import ray
 from ray import serve
 
 from aana.utils.core import sleep_exponential_backoff
 from aana.utils.typing import is_async_generator
+
+logger = logging.getLogger(__name__)
 
 
 class AanaDeploymentHandle:
@@ -67,9 +72,16 @@ class AanaDeploymentHandle:
                     except Exception as e:
                         is_retryable = self.retry_exceptions is True or (
                             isinstance(self.retry_exceptions, list)
-                            and isinstance(
-                                e.cause.__class__, tuple(self.retry_exceptions)
+                            and (
+                                isinstance(
+                                    getattr(e, "cause", None),
+                                    tuple(self.retry_exceptions),
+                                )
+                                or isinstance(e, tuple(self.retry_exceptions))
                             )
+                        )
+                        logger.exception(
+                            f"Error in method {name} on attempt {retries + 1}: {e.__class__}"
                         )
                         if not is_retryable or retries >= self.num_retries:
                             raise
@@ -92,9 +104,16 @@ class AanaDeploymentHandle:
                     except Exception as e:  # noqa: PERF203
                         is_retryable = self.retry_exceptions is True or (
                             isinstance(self.retry_exceptions, list)
-                            and isinstance(
-                                e.cause.__class__, tuple(self.retry_exceptions)
+                            and (
+                                isinstance(
+                                    getattr(e, "cause", None),
+                                    tuple(self.retry_exceptions),
+                                )
+                                or isinstance(e, tuple(self.retry_exceptions))
                             )
+                        )
+                        logger.exception(
+                            f"Error in method {name} on attempt {retries + 1}: {e.__class__}"
                         )
                         if not is_retryable or retries >= self.num_retries:
                             raise
@@ -135,6 +154,13 @@ class AanaDeploymentHandle:
             retry_delay (float): The initial delay between retries.
             retry_max_delay (float): The maximum delay between retries.
         """
+        # Always retry on ActorDiedError to handle actor restarts gracefully.
+        if retry_exceptions is False or isinstance(retry_exceptions, list):
+            retry_exceptions = (
+                retry_exceptions if isinstance(retry_exceptions, list) else []
+            )
+            retry_exceptions.append(ray.exceptions.ActorDiedError)
+
         handle = cls(
             deployment_name=deployment_name,
             num_retries=num_retries,


### PR DESCRIPTION
Introduce logging for retry attempts and ensure that ActorDiedError is handled gracefully during retries. This enhances improves the stability of the SDK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Exceptions are now logged during method retries, showing the exception type and attempt number.
  - Improved retry logic to handle actor restarts more gracefully.

- **Bug Fixes**
  - Ensured that actor failures always trigger retries for more reliable deployments.
  - Prevented errors by safely handling cases where task results may be absent before accessing error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->