### PR TITLE
Allow Disabling Statement Timeout for PostgreSQL

### DIFF
--- a/aana/configs/db.py
+++ b/aana/configs/db.py
@@ -57,7 +57,7 @@ class DbSettings(BaseSettings):
             Default is 10.
         pool_recycle (int): The number of seconds a connection can be idle in the pool before it is invalidated.
             Default is 3600.
-        query_timeout (int): The timeout for database queries in seconds. Default is 30.
+        query_timeout (int): The timeout for database queries in seconds. Default is 30. Set to 0 for no timeout.
         connection_timeout (int): The timeout for database connections in seconds. Default is 10.
     """
 

--- a/aana/storage/op.py
+++ b/aana/storage/op.py
@@ -107,10 +107,11 @@ class DatabaseSessionManager:
         connection_string = (
             f"postgresql+asyncpg://{user}:{password}@{host}:{port}/{database}"
         )
+        server_settings = {}
+        if db_config.query_timeout > 0:
+            server_settings["statement_timeout"] = str(db_config.query_timeout * 1000)
         connect_args = {
-            "server_settings": {
-                "statement_timeout": str(db_config.query_timeout * 1000)
-            }
+            "server_settings": server_settings,
         }
 
         return create_async_engine(


### PR DESCRIPTION
Introduce an option to set the statement timeout to zero to disable it for PostgreSQL connections. This is necessary to integrate with RDS Proxy that doesn't support statement timeout. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of database query timeouts to ensure that no timeout is set when the value is zero or negative.

* **Documentation**
  * Clarified the description of the query timeout setting, specifying that the value is in seconds and that setting it to zero disables the timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->